### PR TITLE
Add note to README about protocol override behind reverse proxy, and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,10 @@ $CONFIG = array (
 	'id' => 'preferred_username',
 	'mail' => 'email',
 ),
+// If you are running Nextcloud behind a reverse proxy, make sure this is set
+'overwriteprotocol' => 'https',
 ```
-Note: You can use the above `Mapper` method to map any arbitrary user attribute in Keycloak to output with standard userdata, allowing use of arbitrary fields for `id`, etc.
+
+**Note:** If necessary, restart Nextcloud to clear the APCu cache for the config file.
+
+**Note:** You can use the above `Mapper` method to map any arbitrary user attribute in Keycloak to output with standard userdata, allowing use of arbitrary fields for `id`, etc.


### PR DESCRIPTION
Adds a small note to the README about making sure Nextcloud treats itself as `https` when running behind a reverse proxy. This prevents the error message `invalid redirect_uri` from Keycloak when following the README instructions on a fresh Nextcloud / Keycloak setup.

Also adds a note about the default APCu cache in use when modifying `config.php`.