### PR TITLE
Improve developer setup by allowing to disable TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ $CONFIG = array (
     // Note: you may want to try setting `oidc_login_logout_url` to your
     // base URL if you face issues regarding re-login after logout
     'oidc_login_alt_login_page' => 'assets/login.php',
+    
+    // for development, it's possible to disable tls verification. Default value is `true`
+    // which should be kept in production
+    `oidc_login_tls_verify` => true,
 );
 ```
 ### Usage with [Keycloak](https://www.keycloak.org/)

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -76,6 +76,9 @@ class LoginController extends Controller
                 $this->config->getSystemValue('oidc_login_client_secret'));
             $oidc->setRedirectURL($callbackUrl);
 
+            // set TLS development mode
+            $oidc->setVerifyHost($this->config->getSystemValue('oidc_login_tls_verify', true));
+            $oidc->setVerifyPeer($this->config->getSystemValue('oidc_login_tls_verify', true));
 
             // Set OpenID Connect Scope
             $scope = $this->config->getSystemValue('oidc_login_scope', 'openid');


### PR DESCRIPTION
I'm making the developer making developer settings https://github.com/pulsejet/nextcloud-oidc-login/tree/master/3rdparty/jumbojett/openid-connect-php#development-environments available via `config.php`