### PR TITLE
Check if $_SERVER has key before access. (#19)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -79,7 +79,8 @@ class Application extends App
         $this->addAltLogin();
 
         // Redirect automatically or show alt login page
-        if ($_SERVER['REQUEST_METHOD'] === 'GET' &&
+        if (array_key_exists('REQUEST_METHOD', $_SERVER) &&
+            $_SERVER['REQUEST_METHOD'] === 'GET' &&
             $request->getPathInfo() === '/login' &&
             $request->getParam('noredir') == null &&
             $request->getParam('user') == null


### PR DESCRIPTION
Check whether the $_SERVER dict has the key 'REQUEST_METHOD' before accessing it. This fixes the periodic error in the logs that appears if the background jobs are handled by cron, i.e. cron.php is called by the PHP cli and thus no request method is set.