### PR TITLE
Mount Home Directory as External Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $CONFIG = array (
     //   ii)  name:     Full name
     //   iii) mail:     Email address
     //   iv)  quota:    NextCloud storage quota
-    //   v)   home:     Home directory location. A symlink to this location is used
+    //   v)   home:     Home directory location. A symlink or external storage to this location is used
     //   vi)  ldap_uid: LDAP uid to search for when running in proxy mode
     'oidc_login_attributes' => array (
         'id' => 'sub',
@@ -45,6 +45,10 @@ $CONFIG = array (
         'quota' => 'ownCloudQuota',
         'home' => 'homeDirectory',
     ),
+
+    // Use external storage instead of a symlink to the home directory
+    // This is disabled by default for backwards compatibility
+    'oidc_login_use_external_storage' => false,
 
     // Set OpenID Connect scope
     'oidc_login_scope' => 'openid profile',

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $CONFIG = array (
     ),
 
     // Use external storage instead of a symlink to the home directory
-    // This is disabled by default for backwards compatibility
+    // Requires the files_external app to be enabled
     'oidc_login_use_external_storage' => false,
 
     // Set OpenID Connect scope

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -68,6 +68,14 @@ class Application extends App
             return;
         }
 
+        // Get the container to pass special parameters
+        $container = $this->getContainer();
+
+        // Get Files_External storage service
+        $storagesService = class_exists('\OCA\Files_External\Service\GlobalStoragesService') ?
+            $this->query(\OCA\Files_External\Service\GlobalStoragesService::class) : null;
+        $container->registerParameter('storagesService', $storagesService);
+
         // Get URLs
         $request = $this->query(IRequest::class);
         $this->redirectUrl = $request->getParam('redirect_url');

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -14,7 +14,6 @@ use OCP\IGroupManager;
 use OCP\ISession;
 use OC\User\LoginException;
 use OCA\OIDCLogin\Provider\OpenIDConnectClient;
-use OCA\Files_External\Service\GlobalStoragesService;
 
 class LoginController extends Controller
 {
@@ -32,8 +31,9 @@ class LoginController extends Controller
     private $session;
     /** @var IL10N */
     private $l;
-    /** @var GlobalStoragesService */
-	private $storagesService;
+    /** @var \OCA\Files_External\Service\GlobalStoragesService */
+    private $storagesService;
+
 
     public function __construct(
         $appName,
@@ -45,7 +45,7 @@ class LoginController extends Controller
         IGroupManager $groupManager,
         ISession $session,
         IL10N $l,
-        GlobalStoragesService $storagesService
+        $storagesService
     ) {
         parent::__construct($appName, $request);
         $this->config = $config;
@@ -216,6 +216,11 @@ class LoginController extends Controller
             $home = $profile[$attr['home']];
 
             if($this->config->getSystemValue('oidc_login_use_external_storage', false)) {
+                // Check if the files external app is enabled and injected
+                if ($this->storagesService === null) {
+                    throw new LoginException($this->l->t('files_external app must be enabled to use oidc_login_use_external_storage'));
+                }
+
                 // Check if the user already has matching storage on their root
                 $storages = array_filter($this->storagesService->getStorages(), function ($storage) use ($uid) {
                     return in_array($uid, $storage->getApplicableUsers()) && // User must own the storage


### PR DESCRIPTION
Allows home directories to be mounted using external storage instead of soft links. 

This has two advantages:

1. It allows existing home directories to be exported to nextcloud (there is no nextcloud-specific folder structure created beneath them)
2. It prevents nextcloud from deleting the home directory when a user is removed 

The symlink behavior is retained by default for backwards compatibility

Closes #29 