### PR TITLE
Create new groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ $CONFIG = array (
     // For development, you may disable TLS verification. Default value is `true`
     // which should be kept in production
     'oidc_login_tls_verify' => true,
+    
+    // If you get your groups from the oidc_login_attributes, you might want 
+    // to create them if they are not already existing, Default is `false`.
+    'oidc_create_groups' => false,
 );
 ```
 ### Usage with [Keycloak](https://www.keycloak.org/)

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -319,6 +319,10 @@ class LoginController extends Controller
                 foreach ($groupNames as $group) {
                     if ($systemgroup = $this->groupManager->get($group)) {
                         $systemgroup->addUser($user);
+                    } else if($this->config->getSystemValue('oidc_create_groups', false) ){
+                        if($systemgroup = $this->groupManager->createGroup($group)) {
+                            $systemgroup->addUser($user);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
You might want to add new groups from oicd by default.
This commit adds new groups if they are not already existing.
This behavior can be modified through the oidc_create_groups flag,
which is default to false to not alter current default behavior.