### PR TITLE
Fix: LdapID Mapping problem

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -191,6 +191,14 @@ class LoginController extends Controller
         if (strlen($uid) > 64) {
             $uid = md5($uid);
         }
+        
+        // Force a UID for existing users with a different user ID in nextcloud than in LDAP 
+        if ($this->config->getSystemValue('oidc_login_proxy_ldap', false)) {
+            $existingUserMapping=$ldap->dn2UserName($dn);
+	    if ($existingUserMapping !== false) {
+                $uid=$existingUserMapping;
+            }
+        }
 
         // Get user with fallback
         $user = $this->userManager->get($uid);


### PR DESCRIPTION

We have the following issue. our nextcloud-server (at version 9 upgraded
from owncloud) has the following problem:

Due to changes in the owncloud-code (around version 7 or 8) and
subsequent changes to our ldap-servers, we have three different internal
userid's for oc_ldap_user_mapping in the field owncloud_name:


> | ldap_dn                                 | owncloud_name                         | directory_uuid |

> | cn=type01,ou=angehoerige,o=XXX          | 0012345-6789-0101-2222-3344556677     | type01         |
> | cn=type02,ou=angehoerige,o=XXX          | 001234567890                          | type02         |
> | cn=type03,ou=angehoerige,o=XXX          | type03                                | type03         |

Since we are talking here about ~3000 users, and about 1200 have the
obfuscated-id (old and new) and the ID is of course dispersed in the
database at a ton of tables, it is not trivial to change the ID's to the
type03 ID's.

Why that:

as long as we use only the user_ldap app, everything works as expected,
without problems, since the internal username is, of course, always
mapped to the ldap_dn ( or more accurately, the other way around, the
ldap_dn is always mapped correctly to the internal username).

however, since we want/need to change to a SSO login, via the app
oidc_login, this won't work, since it expects the internal userid
(owncloud_name) to be the same as the cn (the same problem exists with
the saml plugin), since it is not, it would create a new user, which we
obviously do not want, since it would disrupt everything for the users
with the "old" owncloud_name id's.

this pull request resolves the issue for us.

So, we would appreciate it very much, if that could be merged into the code,
as it has no impact for the instances which do not have this problem.