### PR TITLE
Minor clarification in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ $CONFIG = array (
     'oidc_login_logout_url' => 'https://openid.example.com/thankyou',
 
     // Quota to assign if no quota is specified in the OIDC response (bytes)
+    //
+    // NOTE: If you want to allow NextCloud to manage quotas, omit this option. Do not set it to
+    // zero or -1 or ''.
     'oidc_login_default_quota' => '1000000000',
 
     // Login button text


### PR DESCRIPTION
I feel like an idiot opening this PR... :) 

I had some issues with Nextcloud resetting user quotas, as documented here:

https://www.reddit.com/r/NextCloud/comments/mrtfys/nextcloud_21_quota_keeps_getting_reset/

I thought this was the result of a bug. It's really not. I just didn't realize that the `oidc_login_default_quota` is optional, and that setting it will result in the behavior described in my post on the `r/NextCloud` subreddit.

This pull request contains no modifications to the code. There is just one minor update to the documentation. I'm hoping that maybe people can avoid the aggravation I had to deal with for a few days.

Thanks
--Steve