### PR TITLE
Add WebDAV access using OIDC bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nextcloud OIDC Login
 
-Make possible create users and login via one single OpenID Connect provider. Even though a fork of [nextcloud-social-login](https://github.com/zorn-v/nextcloud-social-login), it fundamentally differs in two ways - aims for simplistic, single provider login (and hence is very minimalastic), and it supports having LDAP as the primary user backend. This way, you can use OpenID Connect to login to Nextcloud while maintaining an LDAP backend with attributes with the LDAP plugin. Supports automatic discovery of endpoints through the OpenID Connect spec, with a single provider configuration attribute.
+Make possible create users and login via one single OpenID Connect provider. Even though a fork of [nextcloud-social-login](https://github.com/zorn-v/nextcloud-social-login), it fundamentally differs in two ways - aims for simplistic, single provider login (and hence is very minimalastic), and it supports having LDAP as the primary user backend. This way, you can use OpenID Connect to login to Nextcloud while maintaining an LDAP backend with attributes with the LDAP plugin. Supports automatic discovery of endpoints through the OpenID Connect spec, with a single provider configuration attribute. It also supports accessing Nextcloud WebDAV using a providers bearer token.
 
 ## Config
 
@@ -136,6 +136,17 @@ $CONFIG = array (
     // If you get your groups from the oidc_login_attributes, you might want
     // to create them if they are not already existing, Default is `false`.
     'oidc_create_groups' => false,
+
+    // Enable use of WebDAV via OIDC bearer token.
+    'oidc_login_webdav_enabled' => false,
+
+    // The time in seconds used to cache public keys from provider.
+    // The default value is 1 day.
+    'oidc_login_public_key_caching_time' => 86400,
+
+    // The minimum time in seconds to wait between requests to the jwks_uri endpoint.
+    // Avoids that the provider will be DoSed when someone requests with unknown kids.
+    'oidc_login_min_time_between_jwks_requests' => 10,
 );
 ```
 ### Usage with [Keycloak](https://www.keycloak.org/)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,12 @@ $CONFIG = array (
 
     // The minimum time in seconds to wait between requests to the jwks_uri endpoint.
     // Avoids that the provider will be DoSed when someone requests with unknown kids.
+    // The default is 10 seconds.
     'oidc_login_min_time_between_jwks_requests' => 10,
+
+    // The time in seconds used to cache the OIDC well-known configuration from the provider.
+    // The default value is 1 day.
+    'oidc_login_well_known_caching_time' => 86400,
 );
 ```
 ### Usage with [Keycloak](https://www.keycloak.org/)

--- a/README.md
+++ b/README.md
@@ -189,3 +189,14 @@ $CONFIG = array (
 **Note:**
 - If necessary, restart Nextcloud to clear the APCu cache for the config file.
 - You can use the above `Mapper` method to map any arbitrary user attribute in Keycloak to output with standard userdata, allowing use of arbitrary fields for `id`, etc.
+
+#### Configuration for WebDAV access
+
+The underlying OIDC library ensures, that the `aud` property of the JWT token contains the configured Nextcloud client ID (config option `oidc_login_client_id`).
+However, when obtaining an access token for a user with a client other than the Nextcloud client (e.g. using rclone), the `aud` property does not contain Nextclouds client ID.
+Thus, the login would fail. The following steps ensure, that access tokens obtained with your client always contain your Nextcloud client in the `aud` property.
+
+1. Go to `Client Scopes`
+1. Add new client scope, call it `nextcloud`.
+1. Under `Mappers` create a new mapper of type `Audience` and ensure that `Included Client Audience` contains your Nextcloud client. Click Save.
+1. Finally, go to `Client > your-client-to-obtain-access-token > Client Scopes` and add the new `nextcloud` scope.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -38,6 +38,16 @@ class Application extends App implements IBootstrap
     public function register(IRegistrationContext $context): void
     {
         $context->registerAlternativeLogin(OIDCLoginOption::class);
+
+        // Try to get Files_External storage service
+        $context->registerService('storagesService', function($container) {
+            $storagesService = null;
+            try {
+                $storagesService = class_exists('\OCA\Files_External\Service\GlobalStoragesService') ?
+                    $container->query(\OCA\Files_External\Service\GlobalStoragesService::class) : null;
+            } catch (Exception $e) {}
+            return $storagesService;
+        });
     }
 
     public function boot(IBootContext $context): void
@@ -47,14 +57,6 @@ class Application extends App implements IBootstrap
         $this->url = $container->query(IURLGenerator::class);
         $this->config = $container->query(IConfig::class);
         $request = $container->query(IRequest::class);
-
-        // Try to get Files_External storage service
-        $storagesService = null;
-        try {
-            $storagesService = class_exists('\OCA\Files_External\Service\GlobalStoragesService') ?
-                $container->query(\OCA\Files_External\Service\GlobalStoragesService::class) : null;
-        } catch (Exception $e) {}
-        $container->registerParameter('storagesService', $storagesService);
 
         // Check if automatic redirection is enabled
         $useLoginRedirect = $this->config->getSystemValue('oidc_login_auto_redirect', false);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -48,6 +48,11 @@ class Application extends App implements IBootstrap
             } catch (Exception $e) {}
             return $storagesService;
         });
+
+        $context->registerEventListener(
+            'OCA\DAV\Connector\Sabre::authInit',
+            '\OCA\OIDCLogin\WebDAV\BearerAuthBackend'
+        );
     }
 
     public function boot(IBootContext $context): void

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OC\User\LoginException;
 use OC\Authentication\Token\DefaultTokenProvider;
 use OCA\OIDCLogin\Provider\OpenIDConnectClient;
+use OCA\OIDCLogin\Service\LoginService;
 
 class LoginController extends Controller
 {
@@ -31,6 +32,8 @@ class LoginController extends Controller
     private $groupManager;
     /** @var ISession */
     private $session;
+    /** @var LoginService */
+    private $loginService;
     /** @var IL10N */
     private $l;
     /** @var \OCA\Files_External\Service\GlobalStoragesService */
@@ -47,6 +50,7 @@ class LoginController extends Controller
         IGroupManager $groupManager,
         ISession $session,
         IL10N $l,
+        LoginService $loginService,
         $storagesService
     ) {
         parent::__construct($appName, $request);
@@ -57,6 +61,7 @@ class LoginController extends Controller
         $this->groupManager = $groupManager;
         $this->session = $session;
         $this->l = $l;
+        $this->loginService = $loginService;
         $this->storagesService = $storagesService;
     }
 
@@ -71,20 +76,7 @@ class LoginController extends Controller
 
         try {
             // Construct new client
-            $oidc = new OpenIDConnectClient(
-                $this->session,
-                $this->config->getSystemValue('oidc_login_provider_url'),
-                $this->config->getSystemValue('oidc_login_client_id'),
-                $this->config->getSystemValue('oidc_login_client_secret'));
-            $oidc->setRedirectURL($callbackUrl);
-
-            // set TLS development mode
-            $oidc->setVerifyHost($this->config->getSystemValue('oidc_login_tls_verify', true));
-            $oidc->setVerifyPeer($this->config->getSystemValue('oidc_login_tls_verify', true));
-
-            // Set OpenID Connect Scope
-            $scope = $this->config->getSystemValue('oidc_login_scope', 'openid');
-            $oidc->addScope($scope);
+            $oidc = $this->loginService->createOIDCClient($callbackUrl);
 
             // Authenticate
             $oidc->authenticate();
@@ -124,258 +116,7 @@ class LoginController extends Controller
             return new RedirectResponse($this->urlGenerator->getAbsoluteURL('/'));
         }
 
-        // Get attributes
-        $confattr = $this->config->getSystemValue('oidc_login_attributes', array());
-        $defattr = array(
-            'id' => 'sub',
-            'name' => 'name',
-            'mail' => 'email',
-            'quota' => 'ownCloudQuota',
-            'home' => 'homeDirectory',
-            'ldap_uid' => 'uid',
-            'groups' => 'ownCloudGroups',
-        );
-        $attr = array_merge($defattr, $confattr);
-
-        // Flatten the profile array
-        $profile = $this->flatten($profile);
-
-        // Get UID
-        $uid = $profile[$attr['id']];
-
-        // Ensure the LDAP user exists if we are proxying for LDAP
-        if ($this->config->getSystemValue('oidc_login_proxy_ldap', false)) {
-            // Get LDAP uid
-            $ldapUid = $profile[$attr['ldap_uid']];
-            if (empty($ldapUid)) {
-                throw new LoginException($this->l->t('No LDAP UID found in OpenID response'));
-            }
-
-            // Get the LDAP user backend
-            $ldap = NULL;
-            foreach ($this->userManager->getBackends() as $backend) {
-                if ($backend->getBackendName() == $this->config->getSystemValue('oidc_login_ldap_backend', "LDAP")) {
-                    $ldap = $backend;
-                }
-            }
-
-            // Check if backend found
-            if ($ldap == NULL) {
-                throw new LoginException($this->l->t('No LDAP user backend found!'));
-            }
-
-            // Get LDAP Access object
-            $access = $ldap->getLDAPAccess($ldapUid);
-
-            // Get the DN
-            $dns = $access->fetchUsersByLoginName($ldapUid);
-            if (empty($dns)) {
-                throw new LoginException($this->l->t('Error getting DN for LDAP user'));
-            }
-            $dn = $dns[0];
-
-            // Store the user
-            $ldapUser = $access->userManager->get($dn);
-            if ($ldapUser == NULL) {
-                throw new LoginException($this->l->t('Error getting user from LDAP'));
-            }
-
-            // Method no longer exists on NC 20+
-            if (method_exists($ldapUser, 'update')) {
-                $ldapUser->update();
-            }
-
-            // Update the email address (#84)
-            if (method_exists($ldapUser, 'updateEmail')) {
-                $ldapUser->updateEmail();
-            }
-
-            // Force a UID for existing users with a different
-            // user ID in nextcloud than in LDAP
-            $uid = $ldap->dn2UserName($dn) ?: $uid;
-        }
-
-        // Check UID
-        if (empty($uid)) {
-            throw new LoginException($this->l->t('Can not get identifier from provider'));
-        }
-
-        // Check max length of uid
-        if (strlen($uid) > 64) {
-            $uid = md5($uid);
-        }
-
-        // Get user with fallback
-        $user = $this->userManager->get($uid);
-        $userPassword = '';
-
-        // Create user if not existing
-        if (null === $user) {
-            if ($this->config->getSystemValue('oidc_login_disable_registration', true)) {
-                throw new LoginException($this->l->t('Auto creating new users is disabled'));
-            }
-
-            $userPassword = substr(base64_encode(random_bytes(64)), 0, 30);
-            $user = $this->userManager->createUser($uid, $userPassword);
-        }
-
-        // Get base data directory
-        $datadir = $this->config->getSystemValue('datadirectory');
-
-        // Set home directory unless proxying for LDAP
-        if (!$this->config->getSystemValue('oidc_login_proxy_ldap', false) &&
-             array_key_exists($attr['home'], $profile)) {
-
-            // Get intended home directory
-            $home = $profile[$attr['home']];
-
-            if($this->config->getSystemValue('oidc_login_use_external_storage', false)) {
-                // Check if the files external app is enabled and injected
-                if ($this->storagesService === null) {
-                    throw new LoginException($this->l->t('files_external app must be enabled to use oidc_login_use_external_storage'));
-                }
-
-                // Check if the user already has matching storage on their root
-                $storages = array_filter($this->storagesService->getStorages(), function ($storage) use ($uid) {
-                    return in_array($uid, $storage->getApplicableUsers()) && // User must own the storage
-                        $storage->getMountPoint() == "/" && // It must be mounted as root
-                        $storage->getBackend()->getIdentifier() == 'local' && // It must be type local
-                        count($storage->getApplicableUsers() == 1); // It can't be shared with other users
-                });
-
-                if(!empty($storages)) {
-                    // User had storage on their / so make sure it's the correct folder
-                    $storage = array_values($storages)[0];
-                    $options = $storage->getBackendOptions();
-
-                    if($options['datadir'] != $home) {
-                        $options['datadir'] = $home;
-                        $storage->setBackendOptions($options);
-                        $this->storagesService->updateStorage($storage);
-                    }
-                } else {
-                    // User didnt have any matching storage on their root, so make one
-                    $storage = $this->storagesService->createStorage('/', 'local', 'null::null', array(
-                        'datadir' => $home
-                    ), array(
-                        'enable_sharing' => true
-                    ));
-                    $storage->setApplicableUsers([$uid]);
-                    $this->storagesService->addStorage($storage);
-                }
-            } else {
-                // Make home directory if does not exist
-                mkdir($home, 0777, true);
-
-                // Home directory (intended) of the user
-                $nhome = "$datadir/$uid";
-
-                // Check if correct link or home directory exists
-                if (!file_exists($nhome) || is_link($nhome)) {
-                    // Unlink if invalid link
-                    if (is_link($nhome) && readlink($nhome) != $home) {
-                        unlink($nhome);
-                    }
-
-                    // Create symlink to directory
-                    if (!is_link($nhome) && !symlink($home, $nhome)) {
-                        throw new LoginException("Failed to create symlink to home directory");
-                    }
-                }
-            }
-        }
-
-        // Update user profile
-        if (!$this->config->getSystemValue('oidc_login_proxy_ldap', false)) {
-            if ($attr['name'] !== null) {
-                $user->setDisplayName($profile[$attr['name']] ?: $profile[$attr['id']]);
-            }
-
-            if ($attr['mail'] !== null) {
-                $user->setEMailAddress((string)$profile[$attr['mail']]);
-            }
-
-            // Set optional params
-            if (array_key_exists($attr['quota'], $profile)) {
-                $user->setQuota((string) $profile[$attr['quota']]);
-            } else {
-                if ($defaultQuota = $this->config->getSystemValue('oidc_login_default_quota')) {
-                    $user->setQuota((string) $defaultQuota);
-                };
-            }
-
-            // Groups to add user in
-            $groupNames = [];
-
-            // Add administrator group from attribute
-            $manageAdmin = array_key_exists('is_admin', $attr) && $attr['is_admin'];
-            if ($manageAdmin) {
-                $adminAttr = $attr['is_admin'];
-                if (array_key_exists($adminAttr, $profile) && $profile[$adminAttr]) {
-                    array_push($groupNames, 'admin');
-                }
-            }
-
-            // Add default group if present
-            if ($defaultGroup = $this->config->getSystemValue('oidc_login_default_group')) {
-                array_push($groupNames, $defaultGroup);
-            }
-
-            // Add user's groups from profile
-            $hasProfileGroups = array_key_exists($attr['groups'], $profile);
-            if ($hasProfileGroups) {
-                // Get group names
-                $profileGroups = $profile[$attr['groups']];
-
-                // Explode by space if string
-                if (is_string($profileGroups)) {
-                    $profileGroups = array_filter(explode(' ', $profileGroups));
-                }
-
-                // Make sure group names is an array
-                if (!is_array($profileGroups)) {
-                    throw new LoginException($attr['groups'] . ' must be an array');
-                }
-
-                // Add to all groups
-                $groupNames = array_merge($groupNames, $profileGroups);
-            }
-
-            // Remove duplicate groups
-            $groupNames = array_unique($groupNames);
-
-            // Remove user from groups not present
-            $currentUserGroups = $this->groupManager->getUserGroups($user);
-            foreach ($currentUserGroups as $currentUserGroup) {
-                if (($key = array_search($currentUserGroup->getDisplayName(), $groupNames)) !== false) {
-                    // User is already in group - don't process further
-                    unset($groupNames[$key]);
-                } else {
-                    // User is not supposed to be in this group
-                    // Remove the user ONLY if we're using profile groups
-                    // or the group is the `admin` group and we manage admin role
-                    if ($hasProfileGroups || ($manageAdmin && $currentUserGroup->getDisplayName() === 'admin')) {
-                        $currentUserGroup->removeUser($user);
-                    }
-                }
-            }
-
-            // Add user to group
-            foreach ($groupNames as $group) {
-                // Get existing group
-                $systemgroup = $this->groupManager->get($group);
-
-                // Create group if does not exist
-                if (!$systemgroup && $this->config->getSystemValue('oidc_create_groups', false)) {
-                    $systemgroup = $this->groupManager->createGroup($group);
-                }
-
-                // Add user to group
-                if ($systemgroup) {
-                    $systemgroup->addUser($user);
-                }
-            }
-        }
+        list($user, $userPassword) = $this->loginService->login($profile);
 
         // Complete login
         $this->userSession->getSession()->regenerateId();
@@ -408,19 +149,5 @@ class LoginController extends Controller
         }
 
         return new RedirectResponse($this->urlGenerator->getAbsoluteURL($redir));
-    }
-
-    private function flatten($array, $prefix = '') {
-        $result = array();
-        foreach($array as $key => $value) {
-            $result[$prefix . $key] = $value;
-            if (is_array($value)) {
-                $result = $result + $this->flatten($value, $prefix . $key . '_');
-            }
-            if (is_int($key) && is_string($value)) {
-                $result[$prefix . $value] = $value;
-            }
-        }
-        return $result;
     }
 }

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -5,20 +5,47 @@ namespace OCA\OIDCLogin\Provider;
 require_once __DIR__ . '/../../3rdparty/autoload.php';
 
 use OCP\ISession;
+use OCP\IConfig;
 
 class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
 {
     /** @var ISession */
     private $session;
+    /** @var IConfig */
+    private $config;
+    /** @var string */
+    private $appName;
+
+    // Keycloak uses a default of 86400 seconds (1 day) as caching time for public keys
+	// https://www.keycloak.org/docs/latest/securing_apps/index.html#_java_adapter_config
+	private const DEFAULT_PUBLIC_KEY_CACHING_TIME = 86400;
+	/** @var int */
+	private $publicKeyCachingTime;
+
+	// Avoid DoSing provider by issuing too many requests triggered by an attacker with bad kids
+	// Keycloak uses a default of 10 seconds as a minimum time between JWKS requests
+	// https://www.keycloak.org/docs/latest/securing_apps/index.html#_java_adapter_config
+	private const DEFAULT_MIN_TIME_BETWEEN_JWKS_REQUESTS = 10;
+	/** @var int */
+	private $minTimeBetweenJwksRequests;
+
     public function __construct(
         ISession $session,
-        $provider_url = null,
-        $client_id = null,
-        $client_secret = null,
+        IConfig $config,
+        string $appName,
         $issuer = null)
     {
-        parent::__construct($provider_url, $client_id, $client_secret, $issuer);
+        $this->config = $config;
+        parent::__construct(
+            $this->config->getSystemValue('oidc_login_provider_url'),
+            $this->config->getSystemValue('oidc_login_client_id'),
+            $this->config->getSystemValue('oidc_login_client_secret'),
+            $issuer
+        );
         $this->session = $session;
+        $this->appName = $appName;
+        $this->publicKeyCachingTime = $this->config->getSystemValue('oidc_login_public_key_caching_time', self::DEFAULT_PUBLIC_KEY_CACHING_TIME);
+        $this->minTimeBetweenJwksRequests = $this->config->getSystemValue('oidc_login_min_time_between_jwks_requests', self::DEFAULT_MIN_TIME_BETWEEN_JWKS_REQUESTS);
     }
     /**
     * {@inheritdoc}
@@ -52,5 +79,90 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     */
     protected function commitSession() {
         $this->startSession();
+    }
+
+    /**
+    * {@inheritdoc}
+    */
+    protected function fetchURL($url, $post_body = null, $headers = array()) {
+        // Avoid endless recursion when calling the initial well-known route
+        if(strpos($url, ".well-known") === false && $url === $this->getProviderConfigValue("jwks_uri")) {
+            // Cache jwks 
+            return $this->getJWKs();
+        }
+        return parent::fetchURL($url, $post_body, $headers);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function verifyJWTsignature($jwt) {
+        try {
+            return parent::verifyJWTsignature($jwt);
+        } catch(\Exception $e) {
+            // As we are caching the JWKs, we might not know the newest ones.
+            // Thus we try verifying the signature first, but if that didn't work because the
+            // key couldn't be found, we fetch new ones and try again.
+            \OC::$server->getLogger()->debug("Error when verifying jwt {$e->getMessage()}");
+            if(strpos($e->getMessage(), "Unable to find a key") !== false) {
+                $this->getJWKs(true);
+                return parent::verifyJWTsignature($jwt);
+            }
+            // Otherwise, rethrow error
+            throw $e;
+        }
+    }
+
+    /**
+     * Fetches new signing keys and stores them for the configured amount of time.
+     * This reduces the requests required to the provider and increases the response time,
+     * especially when using WebDAV.
+     * 
+     * @throws \Jumbojett\OpenIDConnectClientException
+     */
+    private function getJWKs($ignore_cache = false) {
+        $lastFetched = $this->config->getAppValue($this->appName, 'last_updated', 0);
+
+        $keyAge = time() - $lastFetched;
+
+        // Use cache
+        if(!$ignore_cache && $keyAge < $this->publicKeyCachingTime) {
+            return $this->config->getAppValue($this->appName, 'jwks');
+        }
+
+        // Avoid DoSing the provider
+        if(time() - $lastFetched < $this->minTimeBetweenJwksRequests) {
+			\OC::$server->getLogger()->warning("Too many update signing key requests", ["app" => $this->appName]);
+			throw new \Jumbojett\OpenIDConnectClientException("Too many update signing key requests");
+		}
+
+        // Avoid recursion
+        $resp = parent::fetchURL($this->getProviderConfigValue('jwks_uri'));
+
+        $this->config->setAppValue($this->appName, 'jwks', $resp);
+		$this->config->setAppValue($this->appName, 'last_updated', time());
+
+        return $resp;
+    }
+
+    /**
+     * Validates the given bearer token by checking the validity of the tokens signature and claims.
+     * 
+     * @throws \Jumbojett\OpenIDConnectClientException
+     */
+    public function validateBearerToken($token) {
+        $claims = $this->decodeJWT($token, 1);
+        // There is no nonce when validating bearer token
+        $claims->nonce = $this->getNonce();
+        if(!$this->verifyJWTsignature($token)) {
+            throw new \Jumbojett\OpenIDConnectClientException('Unable to verify signature');
+        }
+        if(!$this->verifyJWTclaims($claims)) {
+            throw new \Jumbojett\OpenIDConnectClientException('Unable to verify claims');
+        }
+    }
+
+    public function getTokenPayload($token) {
+        return $this->decodeJWT($token, 1);
     }
 }

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -17,17 +17,22 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     private $appName;
 
     // Keycloak uses a default of 86400 seconds (1 day) as caching time for public keys
-	// https://www.keycloak.org/docs/latest/securing_apps/index.html#_java_adapter_config
-	private const DEFAULT_PUBLIC_KEY_CACHING_TIME = 86400;
-	/** @var int */
-	private $publicKeyCachingTime;
+    // https://www.keycloak.org/docs/latest/securing_apps/index.html#_java_adapter_config
+    private const DEFAULT_PUBLIC_KEY_CACHING_TIME = 86400;
+    /** @var int */
+    private $publicKeyCachingTime;
 
-	// Avoid DoSing provider by issuing too many requests triggered by an attacker with bad kids
-	// Keycloak uses a default of 10 seconds as a minimum time between JWKS requests
-	// https://www.keycloak.org/docs/latest/securing_apps/index.html#_java_adapter_config
-	private const DEFAULT_MIN_TIME_BETWEEN_JWKS_REQUESTS = 10;
-	/** @var int */
-	private $minTimeBetweenJwksRequests;
+    // Avoid DoSing provider by issuing too many requests triggered by an attacker with bad kids
+    // Keycloak uses a default of 10 seconds as a minimum time between JWKS requests
+    // https://www.keycloak.org/docs/latest/securing_apps/index.html#_java_adapter_config
+    private const DEFAULT_MIN_TIME_BETWEEN_JWKS_REQUESTS = 10;
+    /** @var int */
+    private $minTimeBetweenJwksRequests;
+
+    // .well-known/openid-configuration shouldn't change much, so we default to 1 day.
+    private const DEFAULT_WELL_KNOWN_CACHING_TIME = 86400;
+    /** @var int */
+    private $wellKnownCachingTime;
 
     public function __construct(
         ISession $session,
@@ -46,6 +51,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
         $this->appName = $appName;
         $this->publicKeyCachingTime = $this->config->getSystemValue('oidc_login_public_key_caching_time', self::DEFAULT_PUBLIC_KEY_CACHING_TIME);
         $this->minTimeBetweenJwksRequests = $this->config->getSystemValue('oidc_login_min_time_between_jwks_requests', self::DEFAULT_MIN_TIME_BETWEEN_JWKS_REQUESTS);
+        $this->wellKnownCachingTime = $this->config->getSystemValue('oidc_login_well_known_caching_time', self::DEFAULT_WELL_KNOWN_CACHING_TIME);
     }
     /**
     * {@inheritdoc}
@@ -85,8 +91,11 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     * {@inheritdoc}
     */
     protected function fetchURL($url, $post_body = null, $headers = array()) {
-        // Avoid endless recursion when calling the initial well-known route
-        if(strpos($url, ".well-known") === false && $url === $this->getProviderConfigValue("jwks_uri")) {
+        if(strpos($url, "/.well-known/openid-configuration") !== false) {
+            // Cache .well-known
+            return $this->getWellKnown($url);
+        }
+        if($url === $this->getProviderConfigValue("jwks_uri")) {
             // Cache jwks 
             return $this->getJWKs();
         }
@@ -114,6 +123,27 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     }
 
     /**
+     * Fetches the well-known OIDC discovery endpoint and caches the result
+     * for the configured amount of time. This reduces the requests required
+     * to the provider. The openid-configuration shouldn't change much anyway.
+     */
+    private function getWellKnown(string $url) {
+        $lastFetched = $this->config->getAppValue($this->appName, 'last_updated_well_known', 0);
+        $age = time() - $lastFetched;
+        
+        if($age < $this->wellKnownCachingTime) {
+            return $this->config->getAppValue($this->appName, 'well-known');
+        }
+
+        $resp = parent::fetchURL($url);
+
+        $this->config->setAppValue($this->appName, 'well-known', $resp);
+        $this->config->setAppValue($this->appName, 'last_updated_well_known', time());
+
+        return $resp;
+    }
+
+    /**
      * Fetches new signing keys and stores them for the configured amount of time.
      * This reduces the requests required to the provider and increases the response time,
      * especially when using WebDAV.
@@ -121,7 +151,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
      * @throws \Jumbojett\OpenIDConnectClientException
      */
     private function getJWKs($ignore_cache = false) {
-        $lastFetched = $this->config->getAppValue($this->appName, 'last_updated', 0);
+        $lastFetched = $this->config->getAppValue($this->appName, 'last_updated_jwks', 0);
 
         $keyAge = time() - $lastFetched;
 
@@ -132,15 +162,15 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
 
         // Avoid DoSing the provider
         if(time() - $lastFetched < $this->minTimeBetweenJwksRequests) {
-			\OC::$server->getLogger()->warning("Too many update signing key requests", ["app" => $this->appName]);
-			throw new \Jumbojett\OpenIDConnectClientException("Too many update signing key requests");
-		}
+            \OC::$server->getLogger()->warning("Too many update signing key requests", ["app" => $this->appName]);
+            throw new \Jumbojett\OpenIDConnectClientException("Too many update signing key requests");
+        }
 
         // Avoid recursion
         $resp = parent::fetchURL($this->getProviderConfigValue('jwks_uri'));
 
         $this->config->setAppValue($this->appName, 'jwks', $resp);
-		$this->config->setAppValue($this->appName, 'last_updated', time());
+        $this->config->setAppValue($this->appName, 'last_updated_jwks', time());
 
         return $resp;
     }

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -12,6 +12,8 @@ use OCA\OIDCLogin\Provider\OpenIDConnectClient;
 
 class LoginService
 {
+    /** @var string */
+    private $appName;
     /** @var IConfig */
     private $config;
     /** @var IUserManager */
@@ -35,6 +37,7 @@ class LoginService
         IL10N $l,
         $storagesService
     ) {
+        $this->appName = $appName;
         $this->config = $config;
         $this->userManager = $userManager;
         $this->groupManager = $groupManager;
@@ -46,9 +49,9 @@ class LoginService
     public function createOIDCClient($callbackUrl = '') {
         $oidc = new OpenIDConnectClient(
             $this->session,
-            $this->config->getSystemValue('oidc_login_provider_url'),
-            $this->config->getSystemValue('oidc_login_client_id'),
-            $this->config->getSystemValue('oidc_login_client_secret'));
+            $this->config,
+            $this->appName,
+        );
         $oidc->setRedirectURL($callbackUrl);
 
         // set TLS development mode

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace OCA\OIDCLogin\Service;
+
+use OCP\IL10N;
+use OCP\IConfig;
+use OCP\IUserManager;
+use OCP\IGroupManager;
+use OCP\ISession;
+use OC\User\LoginException;
+use OCA\OIDCLogin\Provider\OpenIDConnectClient;
+
+class LoginService
+{
+    /** @var IConfig */
+    private $config;
+    /** @var IUserManager */
+    private $userManager;
+    /** @var IGroupManager */
+    private $groupManager;
+    /** @var ISession */
+    private $session;
+    /** @var IL10N */
+    private $l;
+    /** @var \OCA\Files_External\Service\GlobalStoragesService */
+    private $storagesService;
+
+
+    public function __construct(
+        $appName,
+        IConfig $config,
+        IUserManager $userManager,
+        IGroupManager $groupManager,
+        ISession $session,
+        IL10N $l,
+        $storagesService
+    ) {
+        $this->config = $config;
+        $this->userManager = $userManager;
+        $this->groupManager = $groupManager;
+        $this->session = $session;
+        $this->l = $l;
+        $this->storagesService = $storagesService;
+    }
+
+    public function createOIDCClient($callbackUrl = '') {
+        $oidc = new OpenIDConnectClient(
+            $this->session,
+            $this->config->getSystemValue('oidc_login_provider_url'),
+            $this->config->getSystemValue('oidc_login_client_id'),
+            $this->config->getSystemValue('oidc_login_client_secret'));
+        $oidc->setRedirectURL($callbackUrl);
+
+        // set TLS development mode
+        $oidc->setVerifyHost($this->config->getSystemValue('oidc_login_tls_verify', true));
+        $oidc->setVerifyPeer($this->config->getSystemValue('oidc_login_tls_verify', true));
+
+        // Set OpenID Connect Scope
+        $scope = $this->config->getSystemValue('oidc_login_scope', 'openid');
+        $oidc->addScope($scope);
+        return $oidc;
+    }
+
+    public function login($profile)
+    {
+        // Get attributes
+        $confattr = $this->config->getSystemValue('oidc_login_attributes', array());
+        $defattr = array(
+            'id' => 'sub',
+            'name' => 'name',
+            'mail' => 'email',
+            'quota' => 'ownCloudQuota',
+            'home' => 'homeDirectory',
+            'ldap_uid' => 'uid',
+            'groups' => 'ownCloudGroups',
+        );
+        $attr = array_merge($defattr, $confattr);
+
+        // Flatten the profile array
+        $profile = $this->flatten($profile);
+
+        // Get UID
+        $uid = $profile[$attr['id']];
+
+        // Ensure the LDAP user exists if we are proxying for LDAP
+        if ($this->config->getSystemValue('oidc_login_proxy_ldap', false)) {
+            // Get LDAP uid
+            $ldapUid = $profile[$attr['ldap_uid']];
+            if (empty($ldapUid)) {
+                throw new LoginException($this->l->t('No LDAP UID found in OpenID response'));
+            }
+
+            // Get the LDAP user backend
+            $ldap = NULL;
+            foreach ($this->userManager->getBackends() as $backend) {
+                if ($backend->getBackendName() == $this->config->getSystemValue('oidc_login_ldap_backend', "LDAP")) {
+                    $ldap = $backend;
+                }
+            }
+
+            // Check if backend found
+            if ($ldap == NULL) {
+                throw new LoginException($this->l->t('No LDAP user backend found!'));
+            }
+
+            // Get LDAP Access object
+            $access = $ldap->getLDAPAccess($ldapUid);
+
+            // Get the DN
+            $dns = $access->fetchUsersByLoginName($ldapUid);
+            if (empty($dns)) {
+                throw new LoginException($this->l->t('Error getting DN for LDAP user'));
+            }
+            $dn = $dns[0];
+
+            // Store the user
+            $ldapUser = $access->userManager->get($dn);
+            if ($ldapUser == NULL) {
+                throw new LoginException($this->l->t('Error getting user from LDAP'));
+            }
+
+            // Method no longer exists on NC 20+
+            if (method_exists($ldapUser, 'update')) {
+                $ldapUser->update();
+            }
+
+            // Update the email address (#84)
+            if (method_exists($ldapUser, 'updateEmail')) {
+                $ldapUser->updateEmail();
+            }
+
+            // Force a UID for existing users with a different
+            // user ID in nextcloud than in LDAP
+            $uid = $ldap->dn2UserName($dn) ?: $uid;
+        }
+
+        // Check UID
+        if (empty($uid)) {
+            throw new LoginException($this->l->t('Can not get identifier from provider'));
+        }
+
+        // Check max length of uid
+        if (strlen($uid) > 64) {
+            $uid = md5($uid);
+        }
+
+        // Get user with fallback
+        $user = $this->userManager->get($uid);
+        $userPassword = '';
+
+        // Create user if not existing
+        if (null === $user) {
+            if ($this->config->getSystemValue('oidc_login_disable_registration', true)) {
+                throw new LoginException($this->l->t('Auto creating new users is disabled'));
+            }
+
+            $userPassword = substr(base64_encode(random_bytes(64)), 0, 30);
+            $user = $this->userManager->createUser($uid, $userPassword);
+        }
+
+        // Get base data directory
+        $datadir = $this->config->getSystemValue('datadirectory');
+
+        // Set home directory unless proxying for LDAP
+        if (!$this->config->getSystemValue('oidc_login_proxy_ldap', false) && 
+            array_key_exists($attr['home'], $profile)) {
+
+            // Get intended home directory
+            $home = $profile[$attr['home']];
+
+            if($this->config->getSystemValue('oidc_login_use_external_storage', false)) {
+                // Check if the files external app is enabled and injected
+                if ($this->storagesService === null) {
+                    throw new LoginException($this->l->t('files_external app must be enabled to use oidc_login_use_external_storage'));
+                }
+
+                // Check if the user already has matching storage on their root
+                $storages = array_filter($this->storagesService->getStorages(), function ($storage) use ($uid) {
+                    return in_array($uid, $storage->getApplicableUsers()) && // User must own the storage
+                        $storage->getMountPoint() == "/" && // It must be mounted as root
+                        $storage->getBackend()->getIdentifier() == 'local' && // It must be type local
+                        count($storage->getApplicableUsers() == 1); // It can't be shared with other users
+                });
+
+                if(!empty($storages)) {
+                    // User had storage on their / so make sure it's the correct folder
+                    $storage = array_values($storages)[0];
+                    $options = $storage->getBackendOptions();
+
+                    if($options['datadir'] != $home) {
+                        $options['datadir'] = $home;
+                        $storage->setBackendOptions($options);
+                        $this->storagesService->updateStorage($storage);
+                    }
+                } else {
+                    // User didnt have any matching storage on their root, so make one
+                    $storage = $this->storagesService->createStorage('/', 'local', 'null::null', array(
+                        'datadir' => $home
+                    ), array(
+                        'enable_sharing' => true
+                    ));
+                    $storage->setApplicableUsers([$uid]);
+                    $this->storagesService->addStorage($storage);
+                }
+            } else {
+                // Make home directory if does not exist
+                mkdir($home, 0777, true);
+
+                // Home directory (intended) of the user
+                $nhome = "$datadir/$uid";
+
+                // Check if correct link or home directory exists
+                if (!file_exists($nhome) || is_link($nhome)) {
+                    // Unlink if invalid link
+                    if (is_link($nhome) && readlink($nhome) != $home) {
+                        unlink($nhome);
+                    }
+
+                    // Create symlink to directory
+                    if (!is_link($nhome) && !symlink($home, $nhome)) {
+                        throw new LoginException("Failed to create symlink to home directory");
+                    }
+                }
+            }
+        }
+
+        // Update user profile
+        if (!$this->config->getSystemValue('oidc_login_proxy_ldap', false)) {
+            if ($attr['name'] !== null) {
+                $user->setDisplayName($profile[$attr['name']] ?: $profile[$attr['id']]);
+            }
+
+            if ($attr['mail'] !== null) {
+                $user->setEMailAddress((string)$profile[$attr['mail']]);
+            }
+
+            // Set optional params
+            if (array_key_exists($attr['quota'], $profile)) {
+                $user->setQuota((string) $profile[$attr['quota']]);
+            } else {
+                if ($defaultQuota = $this->config->getSystemValue('oidc_login_default_quota')) {
+                    $user->setQuota((string) $defaultQuota);
+                };
+            }
+
+            // Groups to add user in
+            $groupNames = [];
+
+            // Add administrator group from attribute
+            $manageAdmin = array_key_exists('is_admin', $attr) && $attr['is_admin'];
+            if ($manageAdmin) {
+                $adminAttr = $attr['is_admin'];
+                if (array_key_exists($adminAttr, $profile) && $profile[$adminAttr]) {
+                    array_push($groupNames, 'admin');
+                }
+            }
+
+            // Add default group if present
+            if ($defaultGroup = $this->config->getSystemValue('oidc_login_default_group')) {
+                array_push($groupNames, $defaultGroup);
+            }
+
+            // Add user's groups from profile
+            $hasProfileGroups = array_key_exists($attr['groups'], $profile);
+            if ($hasProfileGroups) {
+                // Get group names
+                $profileGroups = $profile[$attr['groups']];
+
+                // Explode by space if string
+                if (is_string($profileGroups)) {
+                    $profileGroups = array_filter(explode(' ', $profileGroups));
+                }
+
+                // Make sure group names is an array
+                if (!is_array($profileGroups)) {
+                    throw new LoginException($attr['groups'] . ' must be an array');
+                }
+
+                // Add to all groups
+                $groupNames = array_merge($groupNames, $profileGroups);
+            }
+
+            // Remove duplicate groups
+            $groupNames = array_unique($groupNames);
+
+            // Remove user from groups not present
+            $currentUserGroups = $this->groupManager->getUserGroups($user);
+            foreach ($currentUserGroups as $currentUserGroup) {
+                if (($key = array_search($currentUserGroup->getDisplayName(), $groupNames)) !== false) {
+                    // User is already in group - don't process further
+                    unset($groupNames[$key]);
+                } else {
+                    // User is not supposed to be in this group
+                    // Remove the user ONLY if we're using profile groups
+                    // or the group is the `admin` group and we manage admin role
+                    if ($hasProfileGroups || ($manageAdmin && $currentUserGroup->getDisplayName() === 'admin')) {
+                        $currentUserGroup->removeUser($user);
+                    }
+                }
+            }
+
+            // Add user to group
+            foreach ($groupNames as $group) {
+                // Get existing group
+                $systemgroup = $this->groupManager->get($group);
+
+                // Create group if does not exist
+                if (!$systemgroup && $this->config->getSystemValue('oidc_create_groups', false)) {
+                    $systemgroup = $this->groupManager->createGroup($group);
+                }
+
+                // Add user to group
+                if ($systemgroup) {
+                    $systemgroup->addUser($user);
+                }
+            }
+        }
+        return array($user, $userPassword);
+    }
+
+    private function flatten($array, $prefix = '') {
+        $result = array();
+        foreach($array as $key => $value) {
+            $result[$prefix . $key] = $value;
+            if (is_array($value)) {
+                $result = $result + $this->flatten($value, $prefix . $key . '_');
+            }
+            if (is_int($key) && is_string($value)) {
+                $result[$prefix . $value] = $value;
+            }
+        }
+        return $result;
+    }
+}

--- a/lib/WebDAV/BearerAuthBackend.php
+++ b/lib/WebDAV/BearerAuthBackend.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace OCA\OIDCLogin\WebDAV;
+
+use OCA\OIDCLogin\Service\LoginService;
+
+use OCP\ISession;
+use OCP\IUserSession;
+use OCP\ILogger;
+use OCP\IConfig;
+
+use OCP\EventDispatcher\IEventListener;
+use OCP\EventDispatcher\Event;
+
+use Sabre\DAV\Auth\Backend\AbstractBearer;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+class BearerAuthBackend extends AbstractBearer implements IEventListener {
+    /** @var string */
+    private $appName;
+    /** @var IUserSession */
+    private $userSession;
+    /** @var ISession */
+    private $session;
+    /** @var IConfig */
+    private $config;
+    /** @var string */
+    private $principalPrefix;
+    /** @var ILogger */
+    private $logger;
+    /** @var LoginService */
+    private $loginService;
+
+    /**
+     * @param IUserSession $userSession
+     * @param ISession $session
+     * @param string $principalPrefix
+     */
+    public function __construct(
+        string $appName,
+        IUserSession $userSession,
+        ISession $session,
+        IConfig $config,
+        ILogger $logger,
+        LoginService $loginService,
+        $principalPrefix = 'principals/users/')
+    {
+        $this->appName = $appName;
+        $this->userSession = $userSession;
+        $this->session = $session;
+        $this->config = $config;
+        $this->logger = $logger;
+        $this->loginService = $loginService;
+        $this->principalPrefix = $principalPrefix;
+        $this->context = ["app" => $appName];
+
+        // setup realm
+        $defaults = new \OCP\Defaults();
+        $this->realm = $defaults->getName();
+    }
+
+    private function setupUserFs($userId) {
+        \OC_Util::setupFS($userId);
+        $this->session->close();
+        return $this->principalPrefix . $userId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateBearerToken($bearerToken) {
+        \OC_Util::setupFS(); //login hooks may need early access to the filesystem
+
+        if (!$this->userSession->isLoggedIn()) {
+            try {
+                $this->login($bearerToken);
+            } catch (\Exception $e) {
+                $this->logger->debug("WebDAV bearer token validation failed with: {$e->getMessage()}", $this->context);
+                return false;
+            }
+        }
+
+        if ($this->userSession->isLoggedIn()) {
+            return $this->setupUserFs($this->userSession->getUser()->getUID());
+        }
+
+        return false;
+    }
+
+    /**
+     * \Sabre\DAV\Auth\Backend\AbstractBearer::challenge sets an WWW-Authenticate
+     * header which some DAV clients can't handle. Thus we override this function
+     * and make it simply return a 401.
+     *
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     */
+    public function challenge(RequestInterface $request, ResponseInterface $response) {
+        $response->setStatus(401);
+    }
+
+    /**
+     * Tries to log in a user based on the given $bearerToken.
+     * @param string $bearerToken An OIDC JWT bearer token.
+     */
+    private function login(string $bearerToken) {
+        $client = $this->loginService->createOIDCClient();
+        if(is_null($client)) {
+            throw new \Exception("Couldn't create OIDC client!");
+        }
+        
+        $client->validateBearerToken($bearerToken);
+
+        $profile = $client->getTokenPayload($bearerToken);
+
+        list($user, $userPassword) = $this->loginService->login($profile);
+
+        $this->userSession->completeLogin($user, [
+            'loginName' => $user->getUID(),
+            'password' => $userPassword
+        ]);
+    }
+
+    /**
+     * Implements IEventListener::handle.
+     * Registers this class as an authentication backend with Sabre WebDav.
+     */
+    public function handle(Event $event): void {
+        $plugin = $event->getServer()->getPlugin('auth');
+        $webdav_enabled = $this->config->getSystemValue('oidc_login_webdav_enabled', false);
+        
+        if($plugin != null && $webdav_enabled) {
+            $plugin->addBackend($this);
+        }
+    }
+}
+

--- a/lib/WebDAV/BearerAuthBackend.php
+++ b/lib/WebDAV/BearerAuthBackend.php
@@ -89,18 +89,6 @@ class BearerAuthBackend extends AbstractBearer implements IEventListener {
     }
 
     /**
-     * \Sabre\DAV\Auth\Backend\AbstractBearer::challenge sets an WWW-Authenticate
-     * header which some DAV clients can't handle. Thus we override this function
-     * and make it simply return a 401.
-     *
-     * @param RequestInterface $request
-     * @param ResponseInterface $response
-     */
-    public function challenge(RequestInterface $request, ResponseInterface $response) {
-        $response->setStatus(401);
-    }
-
-    /**
      * Tries to log in a user based on the given $bearerToken.
      * @param string $bearerToken An OIDC JWT bearer token.
      */


### PR DESCRIPTION
This PR adds the ability to allow WebDAV access using an OIDC bearer token. This can be useful when using [rclone WebDAV with OIDC](https://rclone.org/webdav/#openid-connect) to synchronize a users files from Nextcloud.

To avoid too much load on the OIDC provider, this PR also adds caching of the JWKs as well as the discovered OIDC configuration for a configurable amount of time.

I suggest reviewing this PR by going through the commits. I tried to make each commit a logical unit of change to aid in the review. 

## Testing

You can use the following script to test this functionality. To pass the tokens `audience` check in the `OpenIDConnectClient.php`, you will need to configure an audience mapper in Keycloak to ensure that your client is included in the `aud` property of the JWT. A [hardcoded audience mapper](https://www.keycloak.org/docs/latest/server_admin/#_audience_hardcoded) is sufficient here. Basically follow the following steps:

1. Go to `Client Scopes`
2. Add new client scope, call it `nextcloud`.
3. Under `Mappers` create a new mapper of type `Audience` and ensure that `Included Client Audience` contains your Nextcloud client ID. Click Save.
4. Finally, go to `Client > your-nextcloud-client > Client Scopes` and add the new `nextcloud` scope.

```bash
#!/bin/bash

KC_BASE="<keycloak-base>" # e.g. http://localhost:8080/auth
KC_REALM="<your-keycloak-realm>"
KC_USERNAME="<keycloak-username>"
KC_PASSWORD="<keycloak-password>"
KC_CLIENT="<your-nextcloud-client>"
KC_SECRET="<your-nextcloud-secret>"

NC_BASE="<nextcloud-base>" # e.g. http://localhost:8081
NC_UID="<nextcloud-user-id>"

resp=$(curl -s -X POST "$KC_BASE/realms/$KC_REALM/protocol/openid-connect/token" \
 -H "Content-Type: application/x-www-form-urlencoded" \
 -d 'grant_type=password' \
 -d "client_id=$KC_CLIENT" -d "client_secret=$KC_SECRET" \
 -d "username=$KC_USERNAME" -d "password=$KC_PASSWORD" \
 -d "scope=nextcloud")

token=$(echo $resp | jq -r .access_token)

[[ ! -n "$token" || "$token" == "null" ]]; then
    echo $resp
    exit 1
fi

curl -X PROPFIND \
    -H "Depth: 1" \
    -H "Authorization: Bearer $token" \
    $NC_BASE/remote.php/dav/files/$NC_UID/
```

If everything worked as expected, you should get a long XML response that looks something like this:

```xml
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
  <d:response>
    <d:href>/remote.php/dav/files/4b5e7a7e-6fd9-4c5a-b4be-18bbfd4eed64/</d:href>
    <d:propstat>
      <d:prop>
        <d:getlastmodified>Sat, 24 Apr 2021 13:50:01 GMT</d:getlastmodified>
        <d:resourcetype>
          <d:collection />
        </d:resourcetype>
        <d:quota-used-bytes>16611184</d:quota-used-bytes>
        <d:quota-available-bytes>-3</d:quota-available-bytes>
        <d:getetag>"60842209bab96"</d:getetag>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```