### PR TITLE
First login failed for existing user

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -389,6 +389,9 @@ class LoginController extends Controller
             'password' => $userPassword,
             'token' => empty($userPassword) ? $token : null,
         ], false);
+        
+        //Workaround to create user files folder. Remove it later.
+        \OC::$server->query(\OCP\Files\IRootFolder::class)->getUserFolder($user->getUID());
 
         // Prevent being asked to change password
         $this->session->set('last-password-confirm', \OC::$server->query(ITimeFactory::class)->getTime());


### PR DESCRIPTION
The user folder is not automatically created when the user already exists, but has never logged in before. `completeLogin` does not create the folder in this case due to token provided token. This missing folder prevents the user from accessing Nextcloud.

See issue https://github.com/pulsejet/nextcloud-oidc-login/issues/104

Thanks to https://github.com/zorn-v for the proposed solution.