### PR TITLE
Implements group-based authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ $CONFIG = array (
     // Default group to add users to (optional, defaults to nothing)
     'oidc_login_default_group' => 'oidc',
 
+    // Authorize only the configured group to access Nextcloud. In case the user
+    // is not assigned to this group (read from oidc_login_attributes) the login
+    // will not be allowed for this user. When the user is not authorized, the user
+    // will neither be created nor its data updated.
+    'oidc_login_authorized_group' => 'admin',
+
     // Use external storage instead of a symlink to the home directory
     // Requires the files_external app to be enabled
     'oidc_login_use_external_storage' => false,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -117,7 +117,7 @@ class Application extends App implements IBootstrap
 
                     header('Location: '.$logoutUrl);
 
-                    exit();
+                    exit;
                 });
             }
 
@@ -151,7 +151,7 @@ class Application extends App implements IBootstrap
             if ($useLoginRedirect) {
                 header('Location: '.$loginLink);
 
-                exit();
+                exit;
             }
 
             // Alt login page
@@ -161,7 +161,7 @@ class Application extends App implements IBootstrap
 
                 require $altLoginPage;
 
-                exit();
+                exit;
             }
         }
     }

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -104,7 +104,7 @@ class LoginController extends Controller
                 $noRedirLoginUrl = $this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm').'?noredir=1';
                 header('Location: '.$noRedirLoginUrl);
 
-                exit();
+                exit;
             }
 
             // Show error page

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -169,6 +169,53 @@ class LoginService
             $uid = md5($uid);
         }
 
+        // Groups to add user in
+        $groupNames = [];
+
+        // Add administrator group from attribute
+        $manageAdmin = \array_key_exists('is_admin', $attr) && $attr['is_admin'];
+        if ($manageAdmin) {
+            $adminAttr = $attr['is_admin'];
+            if (\array_key_exists($adminAttr, $profile) && $profile[$adminAttr]) {
+                $groupNames[] = 'admin';
+            }
+        }
+
+        // Add default group if present
+        if ($defaultGroup = $this->config->getSystemValue('oidc_login_default_group')) {
+            $groupNames[] = $defaultGroup;
+        }
+
+        // Add user's groups from profile
+        $hasProfileGroups = \array_key_exists($attr['groups'], $profile);
+        if ($hasProfileGroups) {
+            // Get group names
+            $profileGroups = $profile[$attr['groups']];
+
+            // Explode by space if string
+            if (\is_string($profileGroups)) {
+                $profileGroups = array_filter(explode(' ', $profileGroups));
+            }
+
+            // Make sure group names is an array
+            if (!\is_array($profileGroups)) {
+                throw new LoginException($attr['groups'].' must be an array');
+            }
+
+            // Add to all groups
+            $groupNames = array_merge($groupNames, $profileGroups);
+        }
+
+        // Remove duplicate groups
+        $groupNames = array_unique($groupNames);
+
+        // Check if authorization is enabled and fail in case user is not in authorized group
+        if ($authorizedGroup = $this->config->getSystemValue('oidc_login_authorized_group')) {
+            if (isset($authorizedGroup) && !empty($authorizedGroup) && !\in_array($authorizedGroup, $groupNames, true)) {
+                throw new LoginException($this->l->t('Access to this application is not allowed'));
+            }
+        }
+
         // Get user with fallback
         $user = $this->userManager->get($uid);
         $userPassword = '';
@@ -288,46 +335,6 @@ class LoginService
                     \OC::$server->getLogger()->debug("Could not load image for {$uid} :  {$e->getMessage()}");
                 }
             }
-
-            // Groups to add user in
-            $groupNames = [];
-
-            // Add administrator group from attribute
-            $manageAdmin = \array_key_exists('is_admin', $attr) && $attr['is_admin'];
-            if ($manageAdmin) {
-                $adminAttr = $attr['is_admin'];
-                if (\array_key_exists($adminAttr, $profile) && $profile[$adminAttr]) {
-                    $groupNames[] = 'admin';
-                }
-            }
-
-            // Add default group if present
-            if ($defaultGroup = $this->config->getSystemValue('oidc_login_default_group')) {
-                $groupNames[] = $defaultGroup;
-            }
-
-            // Add user's groups from profile
-            $hasProfileGroups = \array_key_exists($attr['groups'], $profile);
-            if ($hasProfileGroups) {
-                // Get group names
-                $profileGroups = $profile[$attr['groups']];
-
-                // Explode by space if string
-                if (\is_string($profileGroups)) {
-                    $profileGroups = array_filter(explode(' ', $profileGroups));
-                }
-
-                // Make sure group names is an array
-                if (!\is_array($profileGroups)) {
-                    throw new LoginException($attr['groups'].' must be an array');
-                }
-
-                // Add to all groups
-                $groupNames = array_merge($groupNames, $profileGroups);
-            }
-
-            // Remove duplicate groups
-            $groupNames = array_unique($groupNames);
 
             // Remove user from groups not present
             $currentUserGroups = $this->groupManager->getUserGroups($user);


### PR DESCRIPTION
Support for group-based authroization is implemented in this commit. Only
the configured group defined in plugin configuration is able to access
Nextcloud. This authorized group is being read from optional
'oidc_login_authorized_group' configuration property.

In case the property is configured in plugin configuration and the user
is not assigned to the configured group, the login will not be allowed
for the user by failing the login process with an appropriate error
message. The user groups will be read from OIDC response using the
attribute configured in 'oidc_login_attributes' configuration property.
When the user is not authorized, the user will neither be created nor
its data will be updated in Nextcloud.

Fixes #69