### PR TITLE
Add the feature that use profile attributes from ID Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ $CONFIG = array (
 
     // Hide the NextCloud password change form.
     'oidc_login_hide_password_form' => false,
+    
+    // Use ID Token instead of UserInfo
+    'oidc_login_use_id_token' => false,
 
     // Attribute map for OIDC response. Available keys are:
     //   * id:       Unique identifier for username

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -89,8 +89,14 @@ class LoginController extends Controller
             // Authenticate
             $oidc->authenticate();
 
-            // Get user information from OIDC
-            $user = $oidc->requestUserInfo();
+            $user = NULL;
+            if ($this->config->getSystemValue('oidc_login_use_id_token', false)) {
+                // Get user information from ID Token
+                $user = $oidc->getIdTokenPayload();
+            } else {
+                // Get user information from OIDC
+                $user = $oidc->requestUserInfo();
+            }
 
             // Convert to PHP array and process
             return $this->authSuccess(json_decode(json_encode($user), true));
@@ -389,7 +395,7 @@ class LoginController extends Controller
             'password' => $userPassword,
             'token' => empty($userPassword) ? $token : null,
         ], false);
-        
+
         //Workaround to create user files folder. Remove it later.
         \OC::$server->query(\OCP\Files\IRootFolder::class)->getUserFolder($user->getUID());
 


### PR DESCRIPTION
This PR adds optional feature that use profile attributes (claims) from ID Token, instead of UserInfo endpoint.

For example, Azure AD suggest to use ID Token instead of their UserInfo API ( https://docs.microsoft.com/en-us/azure/active-directory/develop/userinfo#consider-use-an-id-token-instead ), and in fact, some claims like 'preferred_username', 'groups' are not supported on AAD's UserInfo.

You can enable this feature with `'oidc_login_use_id_token' => true`.
