### PR TITLE
implement OIDC logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ $CONFIG = array (
     // Redirect to this page after logging out the user
     'oidc_login_logout_url' => 'https://openid.example.com/thankyou',
 
+    // If set to true the user will be redirected to the logout endpoint of the OIDC provider
+    // after logout in Nextcloud. After successfull logout the OIDC provider will redirect 
+    // back to 'oidc_login_logout_url'.
+    'oidc_login_end_session_redirect' => true,
+
     // Quota to assign if no quota is specified in the OIDC response (bytes)
     //
     // NOTE: If you want to allow NextCloud to manage quotas, omit this option. Do not set it to

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -81,7 +81,7 @@ class Application extends App implements IBootstrap
 
             /* Redirect to logout URL on completing logout
                If do not have logout URL, go to noredir on logout */
-            if ($logoutUrl = $this->config->getSystemValue('oidc_login_logout_url', $noRedirLoginUrl)) {
+            if ($logoutUrl = $session->get('oidc_logout_url', $noRedirLoginUrl)) {
                 $userSession->listen('\OC\User', 'postLogout', function () use ($logoutUrl) {
                     // Do nothing if this is a CORS request
                     if ($this->getContainer()->query(ControllerMethodReflector::class)->hasAnnotation('CORS')) {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -92,6 +92,8 @@ class LoginController extends Controller
             // Get user information from OIDC
             $user = $oidc->requestUserInfo();
 
+            $this->prepareLogout($oidc);
+
             // Convert to PHP array and process
             return $this->authSuccess(json_decode(json_encode($user), true));
 
@@ -115,6 +117,21 @@ class LoginController extends Controller
         }
 
         return $this->login($profile);
+    }
+
+    private function prepareLogout($oidc)
+    {
+        if ($oidc_login_logout_url = $this->config->getSystemValue('oidc_login_logout_url', false)) {
+            if ($this->config->getSystemValue('oidc_login_end_session_redirect', false))
+            {
+                $signout_url = $oidc->getEndSessionUrl($oidc_login_logout_url);
+                $this->session->set('oidc_logout_url', $signout_url);
+            } else {
+                $this->session->set('oidc_logout_url', $oidc_login_logout_url);
+            }
+        } else {
+            $this->session->set('oidc_logout_url', false);
+        }
     }
 
     private function login($profile)

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -53,4 +53,21 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     protected function commitSession() {
         $this->startSession();
     }
+    /**
+     * Gets the OIDC end session URL that will logout the user and redirect back to $post_logout_redirect_uri.
+     * 
+     * @param string $post_logout_redirect_uri Post signout redirect URL.
+     * 
+     * @return string The OIDC logout URL.
+     */
+    public function getEndSessionUrl($post_logout_redirect_uri)
+    {
+        $id_token_hint = $this->getIdToken();
+        $end_session_endpoint =  $this->getProviderConfigValue('end_session_endpoint');
+        $signout_params = array(
+            'id_token_hint' => $id_token_hint,
+            'post_logout_redirect_uri' => $post_logout_redirect_uri);
+        $end_session_endpoint  .= (strpos($end_session_endpoint, '?') === false ? '?' : '&') . http_build_query($signout_params);
+        return $end_session_endpoint;
+    }
 }


### PR DESCRIPTION
We are using your OIDC login plugin to authenticate with our OIDC provider, but found that it does not support to logout the user with the OIDC provider.
I have added this feature in my own repository and it works in our DEV/STAGING environment.
I am not an experienced PHP developer so a close review would be definitely recommended. (resolves #113)