### PR TITLE
openid-connect-php : verifyJWTclaims bugfix port

### DIFF
--- a/3rdparty/jumbojett/openid-connect-php/src/OpenIDConnectClient.php
+++ b/3rdparty/jumbojett/openid-connect-php/src/OpenIDConnectClient.php
@@ -1004,7 +1004,7 @@ class OpenIDConnectClient
             && ($claims->nonce === $this->getNonce())
             && ( !isset($claims->exp) || ((gettype($claims->exp) === 'integer') && ($claims->exp >= time() - $this->leeway)))
             && ( !isset($claims->nbf) || ((gettype($claims->nbf) === 'integer') && ($claims->nbf <= time() + $this->leeway)))
-            && ( !isset($claims->at_hash) || $claims->at_hash === $expected_at_hash )
+            && ( !isset($claims->at_hash) || !isset($accessToken) || $claims->at_hash === $expected_at_hash )
         );
     }
 


### PR DESCRIPTION
Hi. I found a bug in the jumbojett openid-connect-php library. I [sent a patch there](https://github.com/jumbojett/OpenID-Connect-PHP/pull/276) but [the project seems unmaintained](https://github.com/jumbojett/OpenID-Connect-PHP/issues/270) (no commit in more than 1 year, 40+ patches rotting) so I thought it would be useful to post the patch here too, as it directly affects how I can use nextcloud with the [canaille](https://gitlab.com/yaal/canaille) OpenID Connect identity provider.

You can see the details on the openid-connect-php pull request, but to summarize, it fixes a *undefined variable* bug appearing in a certain state when validating the JWT.

This is related to my last comments on #99