### PR TITLE
Allow WebDAV authentication with non JWT tokens

### DIFF
--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -221,7 +221,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
 
                 $parts = explode('.', $token);
 
-                $joseHeader = json_decode(base64url_decode($parts[0]));
+                $joseHeader = json_decode(\Jumbojett\base64url_decode($parts[0]));
                 if(!property_exists($joseHeader, 'alg')) {
                     $accessTokenIsJWT = false;
                     return false;

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -227,7 +227,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
                     return false;
                 }
 
-                json_decode(base64url_decode($parts[1]));
+                json_decode(\Jumbojett\base64url_decode($parts[1]));
                 $accessTokenIsJWT = true;
             }
             catch (\Exception $e) {

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -34,6 +34,9 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     /** @var int */
     private $wellKnownCachingTime;
 
+    /** var bool */
+    private $accessTokenIsJWT;
+
     public function __construct(
         ISession $session,
         IConfig $config,
@@ -181,10 +184,16 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
      * @throws \Jumbojett\OpenIDConnectClientException
      */
     public function validateBearerToken($token) {
-        $claims = $this->decodeJWT($token, 1);
+        if ($this->isJWT($token)) {
+            $claims = $this->decodeJWT($token, 1);
+        }
+        else {
+            $claims = $this->introspectToken($token);
+        }
+
         // There is no nonce when validating bearer token
         $claims->nonce = $this->getNonce();
-        if(!$this->verifyJWTsignature($token)) {
+        if($this->isJWT($token) && !$this->verifyJWTsignature($token)) {
             throw new \Jumbojett\OpenIDConnectClientException('Unable to verify signature');
         }
         if(!$this->verifyJWTclaims($claims)) {
@@ -192,8 +201,41 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
         }
     }
 
-    public function getTokenPayload($token) {
-        return $this->decodeJWT($token, 1);
+    public function getTokenProfile($token) {
+        if ($this->isJWT($token)) {
+            return $this->decodeJWT($token, 1);
+        }
+        else {
+            $this->accessToken = $token;
+            return $this->requestUserInfo();
+        }
+    }
+
+    public function isJWT($token) {
+        if (!isset($accessTokenIsJWT)) {
+            try{
+                if(substr_count($token, '.') < 2) {
+                    $accessTokenIsJWT = false;
+                    return false;
+                }
+
+                $parts = explode('.', $token);
+
+                $joseHeader = json_decode(base64url_decode($parts[0]));
+                if(!property_exists($joseHeader, 'alg')) {
+                    $accessTokenIsJWT = false;
+                    return false;
+                }
+
+                json_decode(base64url_decode($parts[1]));
+                $accessTokenIsJWT = true;
+            }
+            catch (\Exception $e) {
+                $accessTokenIsJWT = false;
+            }
+        }
+
+        return $accessTokenIsJWT;
     }
 
     /**

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -222,7 +222,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
                 $parts = explode('.', $token);
 
                 $joseHeader = json_decode(\Jumbojett\base64url_decode($parts[0]));
-                if(!property_exists($joseHeader, 'alg')) {
+                if($joseHeader == null || !property_exists($joseHeader, 'alg')) {
                     $accessTokenIsJWT = false;
                     return false;
                 }

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -227,7 +227,11 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
                     return false;
                 }
 
-                json_decode(\Jumbojett\base64url_decode($parts[1]));
+                if(json_decode(\Jumbojett\base64url_decode($parts[1])) == null) {
+                    $accessTokenIsJWT = false;
+                    return false;
+                }
+
                 $accessTokenIsJWT = true;
             }
             catch (\Exception $e) {

--- a/lib/WebDAV/BearerAuthBackend.php
+++ b/lib/WebDAV/BearerAuthBackend.php
@@ -100,7 +100,7 @@ class BearerAuthBackend extends AbstractBearer implements IEventListener {
         
         $client->validateBearerToken($bearerToken);
 
-        $profile = $client->getTokenPayload($bearerToken);
+        $profile = $client->getTokenProfile($bearerToken);
 
         list($user, $userPassword) = $this->loginService->login($profile);
 


### PR DESCRIPTION
Hi. I have this setup:
- [canaille](https://gitlab.com/yaal/canaille) as my identity provider
- nextcloud + nextcloud-oidc-login as my resource server for carddav contacts
- roundcube + [rcmcarddav](https://github.com/mstilkerich/rcmcarddav) as my OIDC client, that wants to access the carddav contacts

As discussed in [this bug report](https://github.com/mstilkerich/rcmcarddav/issues/354) it seems that identity providers like Keycloak provide JWT access tokens, although it is not required by the specifications. nextcloud-oidc-login expects access token to be JWT but some providers like canaille do not provide JWT access token, but regular ones.

This patch allows WebDAV authentication with a regular access token. When a non-JWT token is detected (not dot in the string) requests are made on the identity provider introspection endpoint and userinfo endpoint to collect information that would have been in the token if it was a JWT.

@sirkrypt0 I would love to hear your review :pray: 