### PR TITLE
DAV Password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ $CONFIG = array (
     // Enable use of WebDAV via OIDC bearer token.
     'oidc_login_webdav_enabled' => false,
 
+    // Enable authentication with user/password for DAV clients that do not
+    // support token authentication (e.g. DAVx⁵)
+    'oidc_login_password_authentication' => false,
+
     // The time in seconds used to cache public keys from provider.
     // The default value is 1 day.
     'oidc_login_public_key_caching_time' => 86400,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -53,6 +53,11 @@ class Application extends App implements IBootstrap
             'OCA\DAV\Connector\Sabre::authInit',
             '\OCA\OIDCLogin\WebDAV\BearerAuthBackend'
         );
+
+        $context->registerEventListener(
+            'OCA\DAV\Connector\Sabre::authInit',
+            '\OCA\OIDCLogin\WebDAV\BasicAuthBackend'
+        );
     }
 
     public function boot(IBootContext $context): void

--- a/lib/WebDAV/BasicAuthBackend.php
+++ b/lib/WebDAV/BasicAuthBackend.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace OCA\OIDCLogin\WebDAV;
+
+use OCA\OIDCLogin\Service\LoginService;
+
+use OCP\ISession;
+use OCP\IUserSession;
+use OCP\ILogger;
+use OCP\IConfig;
+
+use OCP\EventDispatcher\IEventListener;
+use OCP\EventDispatcher\Event;
+
+use Sabre\DAV\Auth\Backend\AbstractBasic;
+
+class BasicAuthBackend extends AbstractBasic implements IEventListener {
+    /** @var string */
+    private $appName;
+    /** @var IUserSession */
+    private $userSession;
+    /** @var ISession */
+    private $session;
+    /** @var IConfig */
+    private $config;
+    /** @var ILogger */
+    private $logger;
+    /** @var LoginService */
+    private $loginService;
+
+    /**
+     * @param IUserSession $userSession
+     * @param ISession $session
+     * @param string $principalPrefix
+     */
+    public function __construct(
+        string $appName,
+        IUserSession $userSession,
+        ISession $session,
+        IConfig $config,
+        ILogger $logger,
+        LoginService $loginService,
+        $principalPrefix = 'principals/users/')
+    {
+        $this->appName = $appName;
+        $this->userSession = $userSession;
+        $this->session = $session;
+        $this->config = $config;
+        $this->logger = $logger;
+        $this->loginService = $loginService;
+        $this->principalPrefix = $principalPrefix;
+        $this->context = ["app" => $appName];
+
+        // setup realm
+        $defaults = new \OCP\Defaults();
+        $this->realm = $defaults->getName();
+    }
+
+    private function setupUserFs($userId) {
+        \OC_Util::setupFS($userId);
+        $this->session->close();
+        return $this->principalPrefix . $userId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function validateUserPass($username, $password) {
+        \OC_Util::setupFS(); //login hooks may need early access to the filesystem
+
+        if (!$this->userSession->isLoggedIn()) {
+            try {
+                $this->login($username, $password);
+            } catch (\Exception $e) {
+                $this->logger->debug("WebDAV basic token validation failed with: {$e->getMessage()}", $this->context);
+                return false;
+            }
+        }
+
+        if ($this->userSession->isLoggedIn()) {
+            return $this->setupUserFs($this->userSession->getUser()->getUID());
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function login(string $username, string $password) {
+        $client = $this->loginService->createOIDCClient();
+        if(is_null($client)) {
+            throw new \Exception("Couldn't create OIDC client!");
+        }
+
+        $client->addAuthParam([
+            'username' => $username,
+            'password' => $password,
+        ]);
+
+        $token = $client->requestResourceOwnerToken(true);
+
+        $profile = $client->getTokenProfile($token->access_token);
+
+        list($user, $userPassword) = $this->loginService->login($profile);
+
+        $this->userSession->completeLogin($user, [
+            'loginName' => $user->getUID(),
+            'password' => $userPassword
+        ]);
+    }
+
+    /**
+     * Implements IEventListener::handle.
+     * Registers this class as an authentication backend with Sabre WebDav.
+     */
+    public function handle(Event $event): void {
+        $plugin = $event->getServer()->getPlugin('auth');
+        $webdav_enabled = $this->config->getSystemValue('oidc_login_webdav_enabled', false);
+        $password_auth_enabled = $this->config->getSystemValue('oidc_login_password_authentication', false);
+
+        if($plugin != null && $webdav_enabled && $password_auth_enabled) {
+            $plugin->addBackend($this);
+        }
+    }
+}


### PR DESCRIPTION
This follows #99 and fixes #128 by allowing `Basic` DAV authentication when `oidc_login_password_authentication` is set to `true` in the configuration.

This is useful for DAV clients that do not support `Bearer` authentication yet, [such as DAVx⁵](https://forums.bitfire.at/topic/2229/feature-request-oauth-support/8?_=1635183282657) or [GNOME Online Accounts](https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/issues/178).

This use OAuth2 resource owner password flow, that is avoided nowadays and [might be forbidden](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-13#section-3.4) in the future. However, [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3) tells us that:

> The authorization server should take special care when
>   enabling this grant type and only allow it when other flows are not
>   viable.
>
>   This grant type is suitable for clients capable of obtaining the
>   resource owner's credentials (username and password, typically using
>   an interactive form).  It is also used to migrate existing clients
>   using direct authentication schemes such as HTTP Basic or Digest
>   authentication to OAuth by converting the stored credentials to an
>   access token.

So I think this describes the situation with DAVx⁵: other flows are not viable, and this can be seen as a migration tool, until DAVx⁵ developers consider OIDC is mature enough so they implement `Bearer` authentication.

The thing is, DAVx⁵ is the only good DAV client on Android I know, and I would really love it to work with nextcloud.