### PR TITLE
webdav endpoint v1 BasicAuthentication

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -62,6 +62,11 @@ class Application extends App implements IBootstrap
             'OCA\DAV\Connector\Sabre::authInit',
             '\OCA\OIDCLogin\WebDAV\BasicAuthBackend'
         );
+
+        $context->registerEventListener(
+            'OCA\DAV\Connector\Sabre::addPlugin',
+            '\OCA\OIDCLogin\WebDAV\BasicAuthBackend'
+        );
     }
 
     public function boot(IBootContext $context): void

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -333,7 +333,15 @@ class LoginService
 
     public function completeLogin($user, $userPassword, $userSession, $request)
     {
-        $userSession->getSession()->regenerateId();
+        /* On the v1 route /remote.php/webdav, a default nextcloud backend
+         * tries and fails to authenticate users, then close the session.
+         * This is why this check is needed.
+         * https://github.com/nextcloud/server/issues/31091
+         */
+        if (PHP_SESSION_ACTIVE === session_status()) {
+            $userSession->getSession()->regenerateId();
+        }
+
         $tokenProvider = \OC::$server->query(DefaultTokenProvider::class);
         $userSession->setTokenProvider($tokenProvider);
         $userSession->createSessionToken($request, $user->getUID(), $user->getUID());

--- a/lib/WebDAV/BasicAuthBackend.php
+++ b/lib/WebDAV/BasicAuthBackend.php
@@ -105,7 +105,15 @@ class BasicAuthBackend extends AbstractBasic implements IEventListener
     private function setupUserFs($userId)
     {
         \OC_Util::setupFS($userId);
-        $this->session->close();
+
+        /* On the v1 route /remote.php/webdav, a default nextcloud backend
+         * tries and fails to authenticate users, then close the session.
+         * This is why this check is needed.
+         * https://github.com/nextcloud/server/issues/31091
+         */
+        if (PHP_SESSION_ACTIVE === session_status()) {
+            $this->session->close();
+        }
 
         return $this->principalPrefix.$userId;
     }


### PR DESCRIPTION
This allows clients that still use the `/remote.php/webdav` endpoint, such as [GNOME Online Accounts](https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/issues/67) to authenticate against a OIDC identity provider with user and password.

It registers the `BasicAuthBackend` on the `addPlugin` event [raised in v1/webdav.php](
https://github.com/nextcloud/server/blob/a353db2c316773d680f8cfedf036c2b9bc54c16e/apps/dav/appinfo/v1/webdav.php#L80).

Then it avoids to execute session related operations, due to the session always being closed in this situation. I [detailed this issue on the nextcloud/server bugtracker](https://github.com/nextcloud/server/issues/31091), but to summarize, the default authentication backend plugged in the `remote.php/webdav` endpoint always closes the session before our backend can do anything.

Due to that issue, the logs are full of [`login failed` warnings](https://github.com/nextcloud/server/blob/f9fb5f50dd1e4db8a81ad935c29f3490d1f9fa79/lib/private/User/Manager.php#L232) raised by the default authentication backend, even if the authentication by our backend succeeds in the end.

I would love to hear your thoughts on this @sirkrypt0, as I am not sure how bad the `if (PHP_SESSION_ACTIVE === session_status())` parts are, and if you can think of another way to do.

This patch depends on #159 and fixes #149.