### PR TITLE
Properly close session and clear browsers storage data on logout

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -103,11 +103,17 @@ class Application extends App implements IBootstrap
             /* Redirect to logout URL on completing logout
                If do not have logout URL, go to noredir on logout */
             if ($logoutUrl = $session->get('oidc_logout_url', $noRedirLoginUrl)) {
-                $userSession->listen('\OC\User', 'postLogout', function () use ($logoutUrl) {
+                $userSession->listen('\OC\User', 'postLogout', function () use ($logoutUrl, $session) {
                     // Do nothing if this is a CORS request
                     if ($this->getContainer()->query(ControllerMethodReflector::class)->hasAnnotation('CORS')) {
                         return;
                     }
+
+                    // Properly close the session and clear the browsers storage data before
+                    // redirecting to the logout url.
+                    $session->set('clearingExecutionContexts', '1');
+                    $session->close();
+                    header('Clear-Site-Data: "cache", "storage"');
 
                     header('Location: '.$logoutUrl);
 


### PR DESCRIPTION
Previously, we'd just redirect the user to the logout url, without
properly closing the session. This would lead to issues as described
in #115, where a user might be able to access another user's local
storage database.

As we hook into the postLogout event, which occurs during
the logout process, but not quite at the end of it, we have to do
some manual work to properly close the session.
(see https://github.com/nextcloud/server/blob/f9fb5f50dd1e4db8a81ad935c29f3490d1f9fa79/core/Controller/LoginController.php#L133-L147)

We now instruct the session the clear the execution contexts and
close it properly. Furthermore, we instruct the browser to clear
the associated cache and storage data.