### PR TITLE
Add Nextcloud proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ $CONFIG = array (
     // This may lead to security issues as the server does not control
     // which URLs will be requested. Use with care.
     'oidc_login_update_avatar' => false,
+
+    // If true, the default Nextcloud proxy won't be used to make internals OIDC call.
+    // The default is false.
+    'oidc_login_skip_proxy' => false,
 );
 ```
 ### Usage with [Keycloak](https://www.keycloak.org/)

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -56,6 +56,13 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
             $this->config->getSystemValue('oidc_login_client_secret'),
             $issuer
         );
+
+        // Get Nextcloud Proxy from system value
+        $proxy = $this->config->getSystemValue('proxy');
+        if (!empty($proxy)) {
+            $this->setHttpProxy($proxy);
+        }
+
         $this->session = $session;
         $this->appName = $appName;
         $this->publicKeyCachingTime = $this->config->getSystemValue('oidc_login_public_key_caching_time', self::DEFAULT_PUBLIC_KEY_CACHING_TIME);

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -22,6 +22,9 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     // .well-known/openid-configuration shouldn't change much, so we default to 1 day.
     private const DEFAULT_WELL_KNOWN_CACHING_TIME = 86400;
 
+    // Don't skip Nextcloud HTTP proxy by default
+    private const DEFAULT_SKIP_PROXY = false;
+
     /** @var ISession */
     private $session;
 
@@ -57,9 +60,11 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
             $issuer
         );
 
-        // Get Nextcloud Proxy from system value
+        // Get Nextcloud proxy from system value
         $proxy = $this->config->getSystemValue('proxy');
-        if (!empty($proxy)) {
+
+        // Enable proxy only if set in configuration and not skipped
+        if (!empty($proxy) && !$this->config->getSystemValue('oidc_login_skip_proxy', self::DEFAULT_SKIP_PROXY)) {
             $this->setHttpProxy($proxy);
         }
 


### PR DESCRIPTION
Add the support of the Nextcloud HTTP proxy configuration.

Example: When a server is behind a firewall that obligate to use a given proxy for all HTTP(S) request, it's impossible to use this app.