### PR TITLE
Use ITokenProvider instead of DefaultTokenProvider for NC24

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,6 +20,6 @@ Make possible create users and login via one single OpenID Connect provider. Eve
     <repository>https://github.com/pulsejet/nextcloud-single-openid-connect</repository>
     <screenshot>https://raw.githubusercontent.com/pulsejet/nextcloud-single-openid-connect/master/appinfo/screenshot.png</screenshot>
     <dependencies>
-        <nextcloud min-version="20" max-version="23" />
+        <nextcloud min-version="20" max-version="24" />
     </dependencies>
 </info>

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -2,7 +2,7 @@
 
 namespace OCA\OIDCLogin\Service;
 
-use OC\Authentication\Token\DefaultTokenProvider;
+use OC\Authentication\Token\IProvider;
 use OC\User\LoginException;
 use OCA\OIDCLogin\Provider\OpenIDConnectClient;
 use OCP\IConfig;
@@ -31,6 +31,9 @@ class LoginService
     /** @var IL10N */
     private $l;
 
+    /** @var IProvider */
+    private $tokenProvider;
+
     /** @var \OCA\Files_External\Service\GlobalStoragesService */
     private $storagesService;
 
@@ -41,6 +44,7 @@ class LoginService
         IGroupManager $groupManager,
         ISession $session,
         IL10N $l,
+        IProvider $tokenProvider,
         $storagesService
     ) {
         $this->appName = $appName;
@@ -49,6 +53,7 @@ class LoginService
         $this->groupManager = $groupManager;
         $this->session = $session;
         $this->l = $l;
+        $this->tokenProvider = $tokenProvider;
         $this->storagesService = $storagesService;
     }
 
@@ -342,10 +347,9 @@ class LoginService
             $userSession->getSession()->regenerateId();
         }
 
-        $tokenProvider = \OC::$server->query(DefaultTokenProvider::class);
-        $userSession->setTokenProvider($tokenProvider);
+        $userSession->setTokenProvider($this->tokenProvider);
         $userSession->createSessionToken($request, $user->getUID(), $user->getUID());
-        $token = $tokenProvider->getToken($userSession->getSession()->getId());
+        $token = $this->tokenProvider->getToken($userSession->getSession()->getId());
 
         $userSession->completeLogin($user, [
             'loginName' => $user->getUID(),


### PR DESCRIPTION
NC24 removed the DefaultTokenProvider from the private package
so we can't access it anymore. Alternatively, we can use the ITokenProvider
interface to receive a similar token provider instance.
Applying this fix makes the plugin work with Nextcloud 24.

Issue: #172