### PR TITLE
Implements group-based authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ $CONFIG = array (
     // Default group to add users to (optional, defaults to nothing)
     'oidc_login_default_group' => 'oidc',
 
+    // Allow only users in configured group(s) to access Nextcloud. In case the user
+    // is not assigned to this group (read from oidc_login_attributes) the login
+    // will not be allowed for this user.
+    //
+    // Must be specified as an array of groups that are allowed to access Nextcloud.
+    // e.g. 'oidc_login_allowed_groups' => array('group1', 'group2')
+    'oidc_login_allowed_groups' => null,
+
     // Use external storage instead of a symlink to the home directory
     // Requires the files_external app to be enabled
     'oidc_login_use_external_storage' => false,

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -119,6 +119,14 @@ class LoginService
             $uid = md5($uid);
         }
 
+        // Check if user is in allowed groups
+        if ($allowedGroups = $this->config->getSystemValue('oidc_login_allowed_groups', null)) {
+            $groupNames = $this->getGroupNames($profile);
+            if (empty(array_intersect($allowedGroups, $groupNames))) {
+                throw new LoginException($this->l->t('Access to this service is not allowed because you are not member of the allowed groups. If you think this is an error, contact your administrator.'));
+            }
+        }
+
         // Get user with fallback
         $user = $this->userManager->get($uid);
         $userPassword = '';


### PR DESCRIPTION
Rebased from #111 by @djessich

Closes #111, closes #183, fixes #69

Support for group-based authroization is implemented in this commit. Only the configured group defined in plugin configuration is able to access Nextcloud. This authorized group is being read from optional 'oidc_login_authorized_group' configuration property.

In case the property is configured in plugin configuration and the user is not assigned to the configured group, the login will not be allowed for the user by failing the login process with an appropriate error message. The user groups will be read from OIDC response using the attribute configured in 'oidc_login_attributes' configuration property. When the user is not authorized, the user will neither be created nor its data will be updated in Nextcloud.

Fixes #69