### PR TITLE
Implement PKCE flow (closing #134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ $CONFIG = array (
     // If true, the default Nextcloud proxy won't be used to make internals OIDC call.
     // The default is false.
     'oidc_login_skip_proxy' => false,
+
+    // Code challenge method for PKCE flow. 
+    // Possible values are:
+    //	- 'S256'
+    //	- 'plain'
+    // The default value is empty, which won't apply the PKCE flow.
+    'oidc_login_code_challenge_method' => '',
 );
 ```
 ### Usage with [Keycloak](https://www.keycloak.org/)
@@ -236,6 +243,10 @@ $CONFIG = array (
 ),
 // If you are running Nextcloud behind a reverse proxy, make sure this is set
 'overwriteprotocol' => 'https',
+```
+4. (optional) Enable the [PKCE flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-proof-key-for-code-exchange-pkce) by setting the value `Clients` &rarr; `Your NC client` &rarr; `Advanced` &rarr; `Proof Key for Code Exchange Code Challenge Method` to `S256`. Please also set the appropriate configuration value accordingly:
+```php
+'oidc_login_code_challenge_method' => 'S256',
 ```
 
 **Note:**

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -60,6 +60,11 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
             $issuer
         );
 
+        $codeChallengeMethod = $this->config->getSystemValue('oidc_login_code_challenge_method');
+        if (!empty($codeChallengeMethod)) {
+            $this->setCodeChallengeMethod($codeChallengeMethod);
+        }
+
         // Get Nextcloud proxy from system value
         $proxy = $this->config->getSystemValue('proxy');
 


### PR DESCRIPTION
This PR introduces the new optional config value `oidc_login_code_challenge_method` to be able to configure the PKCE flow. 

Signed-off-by: Robin Windey <ro.windey@gmail.com>