### PR TITLE
Use provider session and refresh tokens 

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -6,7 +6,6 @@ namespace OCA\OIDCLogin\AppInfo;
 
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCA\OIDCLogin\OIDCLoginOption;
-use OCA\OIDCLogin\Service\TokenService;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -32,7 +31,6 @@ class Application extends App implements IBootstrap
     protected $config;
     private $appName = 'oidc_login';
 
-    private $tokenService;
 
     public function __construct()
     {
@@ -76,7 +74,6 @@ class Application extends App implements IBootstrap
     {
         $container = $context->getAppContainer();
         $this->l = $container->query(IL10N::class);
-        $this->tokenService = $container->query(TokenService::class);
         $this->url = $container->query(IURLGenerator::class);
         $this->config = $container->query(IConfig::class);
         $request = $container->query(IRequest::class);
@@ -125,11 +122,6 @@ class Application extends App implements IBootstrap
                 });
             }
 
-            if (!$this->tokenService->refreshTokens()) {
-                $userSession->logout();
-
-                return;
-            }
 
             // Hide password change form
             if ($this->config->getSystemValue('oidc_login_hide_password_form', false)) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -6,6 +6,7 @@ namespace OCA\OIDCLogin\AppInfo;
 
 use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCA\OIDCLogin\OIDCLoginOption;
+use OCA\OIDCLogin\Service\TokenService;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -30,6 +31,8 @@ class Application extends App implements IBootstrap
     /** @var Config */
     protected $config;
     private $appName = 'oidc_login';
+
+    private $tokenService;
 
     public function __construct()
     {
@@ -73,6 +76,7 @@ class Application extends App implements IBootstrap
     {
         $container = $context->getAppContainer();
         $this->l = $container->query(IL10N::class);
+        $this->tokenService = $container->query(TokenService::class);
         $this->url = $container->query(IURLGenerator::class);
         $this->config = $container->query(IConfig::class);
         $request = $container->query(IRequest::class);
@@ -119,6 +123,12 @@ class Application extends App implements IBootstrap
 
                     exit;
                 });
+            }
+
+            if (!$this->tokenService->refreshTokens()) {
+                $userSession->logout();
+
+                return;
             }
 
             // Hide password change form

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace OCA\OIDCLogin\AppInfo;
 
 use OC\AppFramework\Utility\ControllerMethodReflector;
+use OCA\OIDCLogin\Listeners\BeforeTemplateRenderedListener;
 use OCA\OIDCLogin\OIDCLoginOption;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -30,7 +32,6 @@ class Application extends App implements IBootstrap
     /** @var Config */
     protected $config;
     private $appName = 'oidc_login';
-
 
     public function __construct()
     {
@@ -68,6 +69,8 @@ class Application extends App implements IBootstrap
             'OCA\DAV\Connector\Sabre::addPlugin',
             '\OCA\OIDCLogin\WebDAV\BasicAuthBackend'
         );
+
+        $context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
     }
 
     public function boot(IBootContext $context): void
@@ -121,7 +124,6 @@ class Application extends App implements IBootstrap
                     exit;
                 });
             }
-
 
             // Hide password change form
             if ($this->config->getSystemValue('oidc_login_hide_password_form', false)) {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -3,6 +3,7 @@
 namespace OCA\OIDCLogin\Controller;
 
 use OCA\OIDCLogin\Service\LoginService;
+use OCA\OIDCLogin\Service\TokenService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -38,6 +39,9 @@ class LoginController extends Controller
     /** @var LoginService */
     private $loginService;
 
+    /** @var TokenService */
+    private $tokenService;
+
     /** @var IL10N */
     private $l;
 
@@ -55,6 +59,7 @@ class LoginController extends Controller
         ISession $session,
         IL10N $l,
         LoginService $loginService,
+        TokenService $tokenService,
         $storagesService
     ) {
         parent::__construct($appName, $request);
@@ -66,6 +71,7 @@ class LoginController extends Controller
         $this->session = $session;
         $this->l = $l;
         $this->loginService = $loginService;
+        $this->tokenService = $tokenService;
         $this->storagesService = $storagesService;
     }
 
@@ -82,12 +88,13 @@ class LoginController extends Controller
 
         try {
             // Construct new client
-            $oidc = $this->loginService->createOIDCClient($callbackUrl);
+            $oidc = $this->tokenService->createOIDCClient($callbackUrl);
 
             // Authenticate
             $oidc->authenticate();
 
-            $this->loginService->storeTokens($oidc->getTokenResponse());
+            $tokenResponse = $oidc->getTokenResponse();
+            $this->tokenService->storeTokens($tokenResponse);
 
             $user = null;
             if ($this->config->getSystemValue('oidc_login_use_id_token', false)) {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -87,6 +87,8 @@ class LoginController extends Controller
             // Authenticate
             $oidc->authenticate();
 
+            $this->loginService->storeTokens($oidc->getTokenResponse());
+
             $user = null;
             if ($this->config->getSystemValue('oidc_login_use_id_token', false)) {
                 // Get user information from ID Token

--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EcloudAccounts\Listeners;
+
+use OCA\OIDCLogin\Service\TokenService;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\ISession;
+use OCP\IUserSession;
+
+class BeforeTemplateRenderedListener implements IEventListener
+{
+    /** @var string */
+    private $appName;
+
+    /** @var IUserSession */
+    private $userSession;
+
+    /** @var TokenService */
+    private $tokenService;
+
+    /** @var ISession */
+    private $session;
+
+    public function __construct($appName, IUserSession $userSession, ISession $session)
+    {
+        $this->appName = $appName;
+        $this->userSession = $userSession;
+        $this->tokenService = $tokenService;
+        $this->session = $session;
+    }
+
+    public function handle(Event $event): void
+    {
+        if (!($event instanceof BeforeTemplateRenderedEvent) || !$this->userSession->isLoggedIn() || !$this->session->exists('is_oidc')) {
+            return;
+        }
+
+        if (!$this->tokenService->refreshTokens()) {
+            $this->userSession->logout();
+        }
+    }
+}

--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OCA\EcloudAccounts\Listeners;
+namespace OCA\OIDCLogin\Listeners;
 
 use OCA\OIDCLogin\Service\TokenService;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
@@ -35,6 +35,7 @@ class BeforeTemplateRenderedListener implements IEventListener
 
     public function handle(Event $event): void
     {
+        // If user not logged in or not an oidc session, nothing to do
         if (!($event instanceof BeforeTemplateRenderedEvent) || !$this->userSession->isLoggedIn() || !$this->session->exists('is_oidc')) {
             return;
         }

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -192,15 +192,28 @@ class LoginService
         $user->updateLastLoginTimestamp();
     }
 
+    public function storeTokens(object $tokenResponse)
+    {
+        $this->session->set('oidc_access_token', $tokenResponse->access_token);
+        $this->session->set('oidc_refresh_token', $tokenResponse->refresh_token);
+
+        $now = time();
+        $accessTokenExpiresIn = $tokenResponse->expires_in + $now;
+        $refreshTokenExpiresIn = $now + $tokenResponse->refresh_expires_in - 5;
+
+        $this->session->set('oidc_access_token_expires_in', $accessTokenExpiresIn);
+        $this->session->set('oidc_refresh_token_expires_in', $refreshTokenExpiresIn);
+    }
+
     /**
      * If the LDAP backend interface is enabled, make user the
      * user actually exists in LDAP and return the uid.
      *
      * @param null|string $ldapUid
      *
-     * @return null|string LDAP user uid or null if not found
-     *
      * @throws LoginException if LDAP backend is not enabled or user is not found
+     *
+     * @return null|string LDAP user uid or null if not found
      */
     private function getLDAPUserUid($ldapUid)
     {
@@ -258,9 +271,9 @@ class LoginService
      *
      * @param string $uid
      *
-     * @return false|\OCP\IUser User object if created
-     *
      * @throws LoginException If oidc_login_disable_registration is true
+     *
+     * @return false|\OCP\IUser User object if created
      */
     private function createUser($uid)
     {

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -3,55 +3,105 @@
 namespace OCA\OIDCLogin\Service;
 
 use Exception;
+use OCA\OIDCLogin\Provider\OpenIDConnectClient;
+use OCP\IConfig;
 use OCP\ISession;
 use OCP\IURLGenerator;
 
 class TokenService
 {
-    public const USER_AGENT = 'NextcloudOIDCLogin';
+    /** @var string */
+    private $appName;
 
     /** @var ISession */
     private $session;
 
-    private $loginService;
+    /** @var IConfig */
+    private $config;
+
+    /** @var IURLGenerator */
+    private $urlGenerator;
 
     public function __construct(
         $appName,
         ISession $session,
-        LoginService $loginService,
+        IConfig $config,
         IURLGenerator $urlGenerator,
     ) {
         $this->appName = $appName;
         $this->session = $session;
-        $this->loginService = $loginService;
+        $this->config = $config;
         $this->urlGenerator = $urlGenerator;
     }
 
+    /**
+     * @param string $callbackUrl
+     *
+     * @return OpenIDConnectClient Configured instance of OpendIDConnectClient
+     */
+    public function createOIDCClient($callbackUrl = '')
+    {
+        $oidc = new OpenIDConnectClient(
+            $this->session,
+            $this->config,
+            $this->appName,
+        );
+        $oidc->setRedirectURL($callbackUrl);
+
+        // set TLS development mode
+        $oidc->setVerifyHost($this->config->getSystemValue('oidc_login_tls_verify', true));
+        $oidc->setVerifyPeer($this->config->getSystemValue('oidc_login_tls_verify', true));
+
+        // Set OpenID Connect Scope
+        $scope = $this->config->getSystemValue('oidc_login_scope', 'openid');
+        $oidc->addScope($scope);
+
+        return $oidc;
+    }
+
+    /**
+     * @return bool Whether or not valid access token
+     */
     public function refreshTokens(): bool
     {
         $accessTokenExpiresIn = $this->session->get('oidc_access_token_expires_in');
         $now = time();
-        if ($now < $accessTokenExpiresIn) {
+        // If access token hasn't expired yet
+        if (!empty($accessTokenExpiresIn) && $now < $accessTokenExpiresIn) {
             return true;
         }
 
         $refreshTokenExpiresIn = $this->session->get('oidc_refresh_token_expires_in');
         $refreshToken = $this->session->get('oidc_refresh_token');
-        if (!$refreshToken || ($refreshTokenExpiresIn && $now > $refreshTokenExpiresIn)) {
+        // If refresh token doesn't exist or refresh token has expired
+        if (!$refreshToken || (!empty($refreshTokenExpiresIn) && $now > $refreshTokenExpiresIn)) {
             return false;
         }
 
         $callbackUrl = $this->urlGenerator->linkToRouteAbsolute($this->appName.'.login.oidc');
 
+        // Refresh the tokens, return false on failure
         try {
-            $oidc = $this->loginService->createOIDCClient($callbackUrl);
+            $oidc = $this->createOIDCClient($callbackUrl);
             $tokenResponse = $oidc->refreshToken($refreshToken);
+            $this->storeTokens($tokenResponse);
+
+            return true;
         } catch (Exception $e) {
             return false;
         }
+    }
 
-        $this->loginService->storeTokens($tokenResponse);
+    public function storeTokens(object $tokenResponse): void
+    {
+        $this->session->set('oidc_access_token', $tokenResponse->access_token);
+        $this->session->set('oidc_refresh_token', $tokenResponse->refresh_token);
 
-        return true;
+        $now = time();
+        $accessTokenExpiresIn = $tokenResponse->expires_in + $now;
+        $refreshTokenExpiresIn = $now + $tokenResponse->refresh_expires_in - 5;
+
+        $this->session->set('oidc_access_token_expires_in', $accessTokenExpiresIn);
+        $this->session->set('oidc_refresh_token_expires_in', $refreshTokenExpiresIn);
     }
 }

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace OCA\OIDCLogin\Service;
+
+use Exception;
+use OCP\ISession;
+use OCP\IURLGenerator;
+
+class TokenService
+{
+    public const USER_AGENT = 'NextcloudOIDCLogin';
+
+    /** @var ISession */
+    private $session;
+
+    private $loginService;
+
+    public function __construct(
+        $appName,
+        ISession $session,
+        LoginService $loginService,
+        IURLGenerator $urlGenerator,
+    ) {
+        $this->appName = $appName;
+        $this->session = $session;
+        $this->loginService = $loginService;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function refreshTokens(): bool
+    {
+        $accessTokenExpiresIn = $this->session->get('oidc_access_token_expires_in');
+        $now = time();
+        if ($now < $accessTokenExpiresIn) {
+            return true;
+        }
+
+        $refreshTokenExpiresIn = $this->session->get('oidc_refresh_token_expires_in');
+        $refreshToken = $this->session->get('oidc_refresh_token');
+        if (!$refreshToken || ($refreshTokenExpiresIn && $now > $refreshTokenExpiresIn)) {
+            return false;
+        }
+
+        $callbackUrl = $this->urlGenerator->linkToRouteAbsolute($this->appName.'.login.oidc');
+
+        try {
+            $oidc = $this->loginService->createOIDCClient($callbackUrl);
+            $tokenResponse = $oidc->refreshToken($refreshToken);
+        } catch (Exception $e) {
+            return false;
+        }
+
+        $this->loginService->storeTokens($tokenResponse);
+
+        return true;
+    }
+}

--- a/lib/WebDAV/BasicAuthBackend.php
+++ b/lib/WebDAV/BasicAuthBackend.php
@@ -3,6 +3,7 @@
 namespace OCA\OIDCLogin\WebDAV;
 
 use OCA\OIDCLogin\Service\LoginService;
+use OCA\OIDCLogin\Service\TokenService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
@@ -35,6 +36,10 @@ class BasicAuthBackend extends AbstractBasic implements IEventListener
     /** @var LoginService */
     private $loginService;
 
+    /** @var TokenService */
+    private $tokenService;
+
+
     /**
      * @param string $principalPrefix
      */
@@ -46,6 +51,7 @@ class BasicAuthBackend extends AbstractBasic implements IEventListener
         IConfig $config,
         LoggerInterface $logger,
         LoginService $loginService,
+        TokenService $tokenService,
         $principalPrefix = 'principals/users/'
     ) {
         $this->appName = $appName;
@@ -55,6 +61,7 @@ class BasicAuthBackend extends AbstractBasic implements IEventListener
         $this->config = $config;
         $this->logger = $logger;
         $this->loginService = $loginService;
+        $this->tokenService = $tokenService;
         $this->principalPrefix = $principalPrefix;
         $this->context = ['app' => $appName];
 
@@ -123,7 +130,7 @@ class BasicAuthBackend extends AbstractBasic implements IEventListener
      */
     private function login(string $username, string $password)
     {
-        $client = $this->loginService->createOIDCClient();
+        $client = $this->tokenService->createOIDCClient();
         if (null === $client) {
             throw new \Exception("Couldn't create OIDC client!");
         }

--- a/lib/WebDAV/BearerAuthBackend.php
+++ b/lib/WebDAV/BearerAuthBackend.php
@@ -3,6 +3,7 @@
 namespace OCA\OIDCLogin\WebDAV;
 
 use OCA\OIDCLogin\Service\LoginService;
+use OCA\OIDCLogin\Service\TokenService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
@@ -38,6 +39,9 @@ class BearerAuthBackend extends AbstractBearer implements IEventListener
     /** @var LoginService */
     private $loginService;
 
+    /** @var TokenService */
+    private $tokenService;    
+
     /**
      * @param string $principalPrefix
      */
@@ -49,6 +53,7 @@ class BearerAuthBackend extends AbstractBearer implements IEventListener
         IConfig $config,
         LoggerInterface $logger,
         LoginService $loginService,
+        TokenService $tokenService,
         $principalPrefix = 'principals/users/'
     ) {
         $this->appName = $appName;
@@ -58,6 +63,7 @@ class BearerAuthBackend extends AbstractBearer implements IEventListener
         $this->config = $config;
         $this->logger = $logger;
         $this->loginService = $loginService;
+        $this->tokenService = $tokenService;
         $this->principalPrefix = $principalPrefix;
         $this->context = ['app' => $appName];
 
@@ -119,7 +125,7 @@ class BearerAuthBackend extends AbstractBearer implements IEventListener
      */
     private function login(string $bearerToken)
     {
-        $client = $this->loginService->createOIDCClient();
+        $client = $this->tokenService->createOIDCClient();
         if (null === $client) {
             throw new \Exception("Couldn't create OIDC client!");
         }


### PR DESCRIPTION
- Attempt to resolve https://github.com/pulsejet/nextcloud-oidc-login/issues/102
- Keeping in draft as it is being tested
  - Testing with Nextcloud 24 and Keycloak 
- This can also help with performing login at nextcloud webmail(rainloop or snappymail for instance) using the access token from the OIDC provider
- Also did a small refactor of moving the `createOIDCClient` function into a new service called `TokenService`