### PR TITLE
Add oidc_login_allowed_roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ $CONFIG = array (
         'home' => 'homeDirectory',
         'ldap_uid' => 'uid',
         'groups' => 'ownCloudGroups',
+        'roles' => 'realm_access_roles',
         'photoURL' => 'picture',
         'is_admin' => 'ownCloudAdmin',
     ),
@@ -125,6 +126,14 @@ $CONFIG = array (
     // Must be specified as an array of groups that are allowed to access Nextcloud.
     // e.g. 'oidc_login_allowed_groups' => array('group1', 'group2')
     'oidc_login_allowed_groups' => null,
+
+    // Allow only users in configured role(s) to access Nextcloud. In case the user
+    // is not assigned to this role (read from oidc_login_attributes) the login
+    // will not be allowed for this user.
+    //
+    // Must be specified as an array of roles that are allowed to access Nextcloud.
+    // e.g. 'oidc_login_allowed_roles' => array('role1', 'role2')
+    'oidc_login_allowed_roles' => null,
 
     // Use external storage instead of a symlink to the home directory
     // Requires the files_external app to be enabled

--- a/lib/Service/AttributeMap.php
+++ b/lib/Service/AttributeMap.php
@@ -27,8 +27,8 @@ class AttributeMap
     /** @var string Array or space separated string of NC groups for the user */
     private $_groups;
 
-    /** @var string Array or space separated string of roles for the user */
-    private $_roles;
+    /** @var string Array or space separated string of login filter values for the user */
+    private $_login_filter;
 
     /** @var string The URL of the user avatar. */
     private $_photoUrl;
@@ -47,7 +47,7 @@ class AttributeMap
             'home' => 'homeDirectory',
             'ldap_uid' => 'uid',
             'groups' => 'ownCloudGroups',
-            'roles' => 'roles',
+            'login_filter' => 'roles',
             'photoURL' => 'picture',
         ];
         $attr = array_merge($defattr, $confattr);
@@ -59,7 +59,7 @@ class AttributeMap
         $this->_home = $attr['home'];
         $this->_ldapUid = $attr['ldap_uid'];
         $this->_groups = $attr['groups'];
-        $this->_roles = $attr['roles'];
+        $this->_login_filter = $attr['login_filter'];
         $this->_photoUrl = $attr['photoURL'];
 
         // Optional attributes
@@ -160,22 +160,22 @@ class AttributeMap
     }
 
     /**
-     * Get roles from profile.
+     * Get login_filter from profile.
      *
      * @param mixed $profile
      *
      * @return null|array
      */
-    public function roles(&$profile)
+    public function login_filter(&$profile)
     {
-        $roles = self::get($this->_roles, $profile);
+        $login_filter = self::get($this->_login_filter, $profile);
 
         // Explode by space if string
-        if (\is_string($roles)) {
-            $roles = array_filter(explode(' ', $roles));
+        if (\is_string($login_filter)) {
+            $login_filter = array_filter(explode(' ', $login_filter));
         }
 
-        return $roles;
+        return $login_filter;
     }
 
     /**
@@ -213,13 +213,13 @@ class AttributeMap
     }
 
     /**
-     * Returns whether the OIDC response has the roles field in it.
+     * Returns whether the OIDC response has the login_filter field in it.
      *
      * @param array $profile
      */
-    public function hasRoles(&$profile)
+    public function hasLoginFilter(&$profile)
     {
-        return \array_key_exists($this->_roles, $profile);
+        return \array_key_exists($this->_login_filter, $profile);
     }
 
     /**

--- a/lib/Service/AttributeMap.php
+++ b/lib/Service/AttributeMap.php
@@ -27,6 +27,9 @@ class AttributeMap
     /** @var string Array or space separated string of NC groups for the user */
     private $_groups;
 
+    /** @var string Array or space separated string of roles for the user */
+    private $_roles;
+
     /** @var string The URL of the user avatar. */
     private $_photoUrl;
 
@@ -44,6 +47,7 @@ class AttributeMap
             'home' => 'homeDirectory',
             'ldap_uid' => 'uid',
             'groups' => 'ownCloudGroups',
+            'roles' => 'roles',
             'photoURL' => 'picture',
         ];
         $attr = array_merge($defattr, $confattr);
@@ -55,6 +59,7 @@ class AttributeMap
         $this->_home = $attr['home'];
         $this->_ldapUid = $attr['ldap_uid'];
         $this->_groups = $attr['groups'];
+        $this->_roles = $attr['roles'];
         $this->_photoUrl = $attr['photoURL'];
 
         // Optional attributes
@@ -155,6 +160,25 @@ class AttributeMap
     }
 
     /**
+     * Get roles from profile.
+     *
+     * @param mixed $profile
+     *
+     * @return null|array
+     */
+    public function roles(&$profile)
+    {
+        $roles = self::get($this->_roles, $profile);
+
+        // Explode by space if string
+        if (\is_string($roles)) {
+            $roles = array_filter(explode(' ', $roles));
+        }
+
+        return $roles;
+    }
+
+    /**
      * Get photo URL from profile.
      *
      * @param mixed $profile
@@ -186,6 +210,16 @@ class AttributeMap
     public function hasGroups(&$profile)
     {
         return \array_key_exists($this->_groups, $profile);
+    }
+
+    /**
+     * Returns whether the OIDC response has the roles field in it.
+     *
+     * @param array $profile
+     */
+    public function hasRoles(&$profile)
+    {
+        return \array_key_exists($this->_roles, $profile);
     }
 
     /**

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -403,7 +403,6 @@ class LoginService
         }
     }
 
-
     /**
      * Get list of roles of user from OIDC response.
      *
@@ -433,7 +432,6 @@ class LoginService
 
         return $roleNames;
     }
-
 
     /**
      * Get list of groups of user from OIDC response.

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -119,6 +119,7 @@ class LoginService
             $uid = md5($uid);
         }
 
+        // DEPRECATED: This code can be removed once the 'oidc_login_allowed_groups' feature is removed
         // Check if user is in allowed groups
         if ($allowedGroups = $this->config->getSystemValue('oidc_login_allowed_groups', null)) {
             $groupNames = $this->getGroupNames($profile);
@@ -127,11 +128,11 @@ class LoginService
             }
         }
 
-        // Check if user has an allowed role
-        if ($allowedRoles = $this->config->getSystemValue('oidc_login_allowed_roles', null)) {
-            $roleNames = $this->getRoleNames($profile);
-            if (empty(array_intersect($allowedRoles, $roleNames))) {
-                throw new LoginException($this->l->t('Access to this service is not allowed because you do not have one of the allowed roles. If you think this is an error, contact your administrator.'));
+        // Check if user has an allowed login filter value
+        if ($allowedLoginFilterValues = $this->config->getSystemValue('oidc_login_filter_allowed_values', null)) {
+            $loginFilterValues = $this->getLoginFilterValues($profile);
+            if (empty(array_intersect($allowedLoginFilterValues, $loginFilterValues))) {
+                throw new LoginException($this->l->t('Access to this service is not allowed because you do not have one of the allowed login filter values. If you think this is an error, contact your administrator.'));
             }
         }
 
@@ -404,33 +405,33 @@ class LoginService
     }
 
     /**
-     * Get list of roles of user from OIDC response.
+     * Get list of login filter values of user from OIDC response.
      *
      * @param array $profile Profile attribute values
      *
-     * @return string[] List of roles
+     * @return string[] List of login filter values
      */
-    private function getRoleNames(&$profile)
+    private function getLoginFilterValues(&$profile)
     {
-        $roleNames = [];
-        // Add user's roles from profile
-        if ($this->attr->hasRoles($profile)) {
-            // Get roles names
-            $profileRoles = $this->attr->roles($profile);
+        $loginFilterValues = [];
+        // Add user's login filter values from profile
+        if ($this->attr->hasLoginFilter($profile)) {
+            // Get login filter values
+            $profileLoginFilterValues = $this->attr->login_filter($profile);
 
-            // Make sure role names is an array
-            if (!\is_array($profileRoles)) {
-                throw new LoginException('Roles field must be an array, '.\gettype($profileRoles).' given');
+            // Make sure login filter allowed values names is an array
+            if (!\is_array($profileLoginFilterValues)) {
+                throw new LoginException('Login filter values field must be an array, '.\gettype($profileLoginFilterValues).' given');
             }
 
-            // Add to all roles
-            $roleNames = array_merge($roleNames, $profileRoles);
+            // Add to all login filter values
+            $loginFilterValues = array_merge($loginFilterValues, $profileLoginFilterValues);
         }
 
-        // Remove duplicate roles
-        $roleNames = array_unique($roleNames);
+        // Remove duplicate login filter values
+        $loginFilterValues = array_unique($loginFilterValues);
 
-        return $roleNames;
+        return $loginFilterValues;
     }
 
     /**


### PR DESCRIPTION
We use groups to control what shared folders users should be able to access.
We use a role to control which users are allowed to login to nextcloud.
So the 'oidc_login_allowed_groups' feature is not usable for use. In this pull request I added a 'oidc_login_allowed_roles' feature, which works with roles.