### PR TITLE
Add auto centerCrop() when updating avatar

### DIFF
--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -402,6 +402,7 @@ class LoginService
                 if (200 === curl_getinfo($curl, CURLINFO_HTTP_CODE)) {
                     $image = new \OC_Image();
                     $image->loadFromData($raw);
+                    $image->centerCrop();
 
                     $avatar->set($image);
                 }


### PR DESCRIPTION
Use `OC_Image->centerCrop()` to crop images automatically when updating avatar from OIDC provider.

Currently, non-square images raise an error, and thus can't be used as avatar. This PR fixes the issue.