### PR TITLE
Set compatibility to nc27

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,6 +29,6 @@ Provides user creation and login via one single OpenID Connect provider. Even th
     <repository>https://github.com/pulsejet/nextcloud-single-openid-connect</repository>
     <screenshot>https://raw.githubusercontent.com/pulsejet/nextcloud-single-openid-connect/master/appinfo/screenshot.png</screenshot>
     <dependencies>
-        <nextcloud min-version="20" max-version="26" />
+        <nextcloud min-version="20" max-version="27" />
     </dependencies>
 </info>


### PR DESCRIPTION
According to https://github.com/pulsejet/nextcloud-oidc-login/issues/222#issuecomment-1590720857 it works with NC27, so let's bump it