### PR TITLE
Trigger firstLogin event on completeLogin

### DIFF
--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -11,6 +11,9 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ISession;
 use OCP\IUserManager;
+use OCP\IUser;
+use OCP\EventDispatcher\GenericEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 use Psr\Log\LoggerInterface;
 
 class LoginService
@@ -206,7 +209,12 @@ class LoginService
 
         // Update the user's last login timestamp, since the conditions above tend to cause the
         // completeLogin() call above to skip doing so.
-        $user->updateLastLoginTimestamp();
+        $firstTimeLogin = $user->updateLastLoginTimestamp();
+
+        // Same for the firstLogin event
+        if ($firstTimeLogin) {
+            \OC::$server->get(IEventDispatcher::class)->dispatch(IUser::class . '::firstLogin', new GenericEvent($user));
+        }
     }
 
     /**

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -5,15 +5,15 @@ namespace OCA\OIDCLogin\Service;
 use OC\Authentication\Token\IProvider;
 use OC\User\LoginException;
 use OCA\OIDCLogin\Provider\OpenIDConnectClient;
+use OCP\EventDispatcher\GenericEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ISession;
-use OCP\IUserManager;
 use OCP\IUser;
-use OCP\EventDispatcher\GenericEvent;
-use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class LoginService
@@ -213,7 +213,7 @@ class LoginService
 
         // Same for the firstLogin event
         if ($firstTimeLogin) {
-            \OC::$server->get(IEventDispatcher::class)->dispatch(IUser::class . '::firstLogin', new GenericEvent($user));
+            \OC::$server->get(IEventDispatcher::class)->dispatch(IUser::class.'::firstLogin', new GenericEvent($user));
         }
     }
 


### PR DESCRIPTION
The [`::firstLogin` event is triggered](https://github.com/nextcloud/server/blob/5234807c603d3d8eb18d3bea5426ffc0a1981d82/lib/private/User/Session.php#L565) by the session manager when no token is present in [`loginDetails` of the function `completeLogin`](https://github.com/nextcloud/server/blob/5234807c603d3d8eb18d3bea5426ffc0a1981d82/lib/private/User/Session.php#L382-L390).

This is the same problem as the [mining `updateLastLoginTimestamp`](https://github.com/pulsejet/nextcloud-oidc-login/blob/482b0fd18a8a6596b8ae24398897110a954ca310/lib/Service/LoginService.php#L207-L209).