### PR TITLE
set max-version to 31

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,6 +29,6 @@ Provides user creation and login via one single OpenID Connect provider. Even th
     <repository>https://github.com/pulsejet/nextcloud-single-openid-connect</repository>
     <screenshot>https://raw.githubusercontent.com/pulsejet/nextcloud-single-openid-connect/master/appinfo/screenshot.png</screenshot>
     <dependencies>
-        <nextcloud min-version="26" max-version="30" />
+        <nextcloud min-version="26" max-version="31" />
     </dependencies>
 </info>


### PR DESCRIPTION
Nextcloud released Version 31 and this plugin is disabled. Error message:
`App "OpenID Connect Login" cannot be installed because it is not compatible with this version of the server.`
I have not tested if this app actually is compatible though ...