### PR TITLE
Add authorization for the JWKS endpoint in order to use drupal/simple_auth

### DIFF
--- a/3rdparty/jumbojett/openid-connect-php/src/OpenIDConnectClient.php
+++ b/3rdparty/jumbojett/openid-connect-php/src/OpenIDConnectClient.php
@@ -1242,7 +1242,7 @@ class OpenIDConnectClient
                     $fetchResult = $this->fetchURL($this->getProviderConfigValue('jwks_uri'),null,$headers);
                     $jwks = json_decode($fetchResult);
                     if ($jwks === NULL) {
-                        throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri'.$fetchResult.' ]');
+                        throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri');
                     }
                     $jwk = $this->getKeyForHeader($jwks->keys, $header);
                 }

--- a/3rdparty/jumbojett/openid-connect-php/src/OpenIDConnectClient.php
+++ b/3rdparty/jumbojett/openid-connect-php/src/OpenIDConnectClient.php
@@ -346,6 +346,9 @@ class OpenIDConnectClient
 
             $claims = $this->decodeJWT($token_json->id_token, 1);
 
+            // Save the access token
+            $this->accessToken = $token_json->access_token;
+
             // Verify the signature
             if ($this->canVerifySignatures()) {
                 if (!$this->getProviderConfigValue('jwks_uri')) {
@@ -361,8 +364,6 @@ class OpenIDConnectClient
             // Save the id token
             $this->idToken = $token_json->id_token;
 
-            // Save the access token
-            $this->accessToken = $token_json->access_token;
 
             // If this is a valid claim
             if ($this->verifyJWTclaims($claims, $token_json->access_token)) {
@@ -1236,9 +1237,12 @@ class OpenIDConnectClient
                     $jwk = $header->jwk;
                     $this->verifyJWKHeader($jwk);
                 } else {
-                    $jwks = json_decode($this->fetchURL($this->getProviderConfigValue('jwks_uri')));
+                    $headers = ["Authorization: Bearer {$this->accessToken}",
+                        'Accept: application/json'];
+                    $fetchResult = $this->fetchURL($this->getProviderConfigValue('jwks_uri'),null,$headers);
+                    $jwks = json_decode($fetchResult);
                     if ($jwks === NULL) {
-                        throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri');
+                        throw new OpenIDConnectClientException('Error decoding JSON from jwks_uri'.$fetchResult.' ]');
                     }
                     $jwk = $this->getKeyForHeader($jwks->keys, $header);
                 }

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -248,7 +248,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
         }
         if ($url === $this->getProviderConfigValue('jwks_uri')) {
             // Cache jwks
-            return $this->getJWKs();
+            return $this->getJWKs(false, $headers);
         }
 
         return parent::fetchURL($url, $post_body, $headers);
@@ -296,7 +296,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
      *
      * @throws \Jumbojett\OpenIDConnectClientException
      */
-    private function getJWKs($ignore_cache = false)
+    private function getJWKs($ignore_cache = false,$headers = [])
     {
         $lastFetched = $this->appConfig->getValueInt($this->appName, 'last_updated_jwks', 0);
 
@@ -318,7 +318,7 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
         }
 
         // Avoid recursion
-        $resp = parent::fetchURL($this->getProviderConfigValue('jwks_uri'));
+        $resp = parent::fetchURL($this->getProviderConfigValue('jwks_uri'),null,$headers);
 
         // Don't cache non-200 responses.
         // As we didn't find any specification in the standard, what 200 code it should exactly be,


### PR DESCRIPTION
I want to use this app in combination with Drupal. Drupal acts as the OpenID provider. To do this, I installed the extra module Simple OAuth. See https://www.drupal.org/project/simple_oauth . I picked the 6.0.0 release. 

Drupal/simple_oath offers a _jwks_ endpoint. In needs, however, authorization. This PR adds this Access token to the JWKS retrieval call.