### PR TITLE
Enhance capabilities of OpenID Connect Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Provides user creation and login via one single OpenID Connect provider. Even th
 - Automatic redirection from the nextcloud login page to the Identity Provider login page
 - WebDAV endpoints `Bearer` and `Basic` authentication
 - Optional removal of special characters in UID
+- Mapping of multiple names to a single display name
 
 ## Config
 
@@ -58,7 +59,8 @@ $CONFIG = array (
 
     // Attribute map for OIDC response. Available keys are:
     //   * id:           Unique identifier for username
-    //   * name:         Full name
+    //   * name:         Full name, can be a string or an array of strings (use array in case family_name
+    //                   and given_name are received separately from IdP).
     //                      If set to null, existing display name won't be overwritten
     //   * mail:         Email address
     //                      If set to null, existing email address won't be overwritten
@@ -107,6 +109,7 @@ $CONFIG = array (
     // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
     //
     // note: on Keycloak, OIDC name claim = "${given_name} ${family_name}" or one of them if any is missing
+    // note: for ID Austria, OIDC name claim = array('family_name', 'given_name')
     //
     'oidc_login_attributes' => array (
         'id' => 'sub',

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Provides user creation and login via one single OpenID Connect provider. Even th
 - Group creation
 - Automatic redirection from the nextcloud login page to the Identity Provider login page
 - WebDAV endpoints `Bearer` and `Basic` authentication
+- Optional removal of special characters in UID
 
 ## Config
 
@@ -192,6 +193,10 @@ $CONFIG = array (
 
     // Enable use of WebDAV via OIDC bearer token.
     'oidc_login_webdav_enabled' => false,
+
+    // Enable removal of special characters in UID.
+    // The default value is false.
+    'oidc_login_allow_special_characters' => true,
 
     // Enable authentication with user/password for DAV clients that do not
     // support token authentication (e.g. DAVx⁵)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Provides user creation and login via one single OpenID Connect provider. Even th
 - WebDAV endpoints `Bearer` and `Basic` authentication
 - Optional removal of special characters in UID
 - Mapping of multiple names to a single display name
+- Mapping for birthdate
 
 ## Config
 
@@ -76,6 +77,8 @@ $CONFIG = array (
     //                      at user login. This may lead to security issues. Use with care.
     //                      This will only be effective if oidc_login_update_avatar is enabled.
     //   * is_admin:     If this value is truthy, the user is added to the admin group (optional)
+    //   * birthdate:    Since attribute 'birthdate' is supported from NC version 30 onwards, this attribute
+    //                   can be mapped too.
     //
     // The attributes in the OIDC response are flattened by adding the nested
     // array key as the prefix and an underscore. Thus,
@@ -115,6 +118,7 @@ $CONFIG = array (
         'id' => 'sub',
         'name' => 'name',
         'mail' => 'email',
+        'birthdate' => 'birthdate',
         'quota' => 'ownCloudQuota',
         'home' => 'homeDirectory',
         'ldap_uid' => 'uid',

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,6 +18,7 @@ Provides user creation and login via one single OpenID Connect provider. Even th
 - Automatic redirection from the nextcloud login page to the Identity Provider login page
 - WebDAV endpoints `Bearer` and `Basic` authentication
 - Optional removal of special characters in UID
+- Mapping of multiple names to a single display name
 ]]></description>
     <version>3.2.2</version>
     <licence>agpl</licence>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,6 +17,7 @@ Provides user creation and login via one single OpenID Connect provider. Even th
 - Group creation
 - Automatic redirection from the nextcloud login page to the Identity Provider login page
 - WebDAV endpoints `Bearer` and `Basic` authentication
+- Optional removal of special characters in UID
 ]]></description>
     <version>3.2.2</version>
     <licence>agpl</licence>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,6 +19,7 @@ Provides user creation and login via one single OpenID Connect provider. Even th
 - WebDAV endpoints `Bearer` and `Basic` authentication
 - Optional removal of special characters in UID
 - Mapping of multiple names to a single display name
+- Mapping for birthdate
 ]]></description>
     <version>3.2.2</version>
     <licence>agpl</licence>

--- a/lib/Service/AttributeMap.php
+++ b/lib/Service/AttributeMap.php
@@ -9,8 +9,11 @@ class AttributeMap
     /** Unique identifier for username */
     private string $_id;
 
-    /** Full display name of user */
+    /** Display name of user */
     private string $_name;
+
+    /** Full display name of user (optional) */
+    private ?array $_full_name = null;
 
     /** Email address (no overwrite if null) */
     private string $_mail;
@@ -56,7 +59,6 @@ class AttributeMap
         $attr = array_merge($defattr, $confattr);
 
         $this->_id = $attr['id'];
-        $this->_name = $attr['name'];
         $this->_mail = $attr['mail'];
         $this->_quota = $attr['quota'];
         $this->_home = $attr['home'];
@@ -64,6 +66,12 @@ class AttributeMap
         $this->_groups = $attr['groups'];
         $this->_login_filter = $attr['login_filter'];
         $this->_photoUrl = $attr['photoURL'];
+
+        if (is_array($attr['name'])) {
+            $this->_full_name = $attr['name'];
+        } else {
+            $this->_name = $attr['name'];
+        }
 
         // Optional attributes
         if (\array_key_exists('is_admin', $attr)) {
@@ -96,7 +104,11 @@ class AttributeMap
      */
     public function name(array $profile): ?string
     {
-        return self::get($this->_name, $profile);
+        if (null !== $this->_full_name) {
+            return self::getFullDisplayName($this->_full_name, $profile);
+        } else {
+            return self::get($this->_name, $profile);
+        }
     }
 
     /**
@@ -208,5 +220,14 @@ class AttributeMap
         }
 
         return null;
+    }
+
+    private static function getFullDisplayName(array|string $attr, array $profile): string
+    {
+        $nameArr = array();
+        foreach ($attr as $value) {
+            $nameArr[] = self::get($value, $profile);
+        }
+        return \implode(' ', $nameArr);
     }
 }

--- a/lib/Service/AttributeMap.php
+++ b/lib/Service/AttributeMap.php
@@ -36,8 +36,11 @@ class AttributeMap
     /** If this value is truthy, the user is added to the admin group (optional) */
     private ?string $_isAdmin = null;
 
+    private IConfig $config;
+
     public function __construct(IConfig $config)
     {
+        $this->config = $config;
         $confattr = $config->getSystemValue('oidc_login_attributes', []);
         $defattr = [
             'id' => 'sub',
@@ -69,11 +72,23 @@ class AttributeMap
     }
 
     /**
+     * Function to remove unallowed characters.
+     */
+    public function base64url_encode($data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
      * Get ID from profile.
      */
     public function id(array $profile): ?string
     {
-        return self::get($this->_id, $profile);
+        if ($this->config->getSystemValue('oidc_login_allow_special_characters', false) === true) {
+            return self::base64url_encode(self::get($this->_id, $profile));
+        } else {
+            return self::get($this->_id, $profile);
+        }
     }
 
     /**

--- a/lib/Service/AttributeMap.php
+++ b/lib/Service/AttributeMap.php
@@ -18,6 +18,9 @@ class AttributeMap
     /** Email address (no overwrite if null) */
     private string $_mail;
 
+    /** Birthdate (optional) */
+    private ?string $_birthdate = null;
+
     /** Usage quota for user */
     private string $_quota;
 
@@ -49,6 +52,7 @@ class AttributeMap
             'id' => 'sub',
             'name' => 'name',
             'mail' => 'email',
+            'birthdate' => 'birthdate',
             'quota' => 'ownCloudQuota',
             'home' => 'homeDirectory',
             'ldap_uid' => 'uid',
@@ -76,6 +80,10 @@ class AttributeMap
         // Optional attributes
         if (\array_key_exists('is_admin', $attr)) {
             $this->_isAdmin = $attr['is_admin'];
+        }
+
+        if (\array_key_exists('birthdate', $attr)) {
+            $this->_birthdate = $attr['birthdate'];
         }
     }
 
@@ -117,6 +125,14 @@ class AttributeMap
     public function mail(array $profile): ?string
     {
         return self::get($this->_mail, $profile);
+    }
+
+    /**
+     * Get birthdate from profile.
+     */
+    public function birthdate(array $profile): ?string
+    {
+        return self::get($this->_birthdate, $profile);
     }
 
     /**


### PR DESCRIPTION
During the integration of the Nextcloud OIDC plugin with ID Austria (the official eID of Austria), we encountered several limitations that may also arise when integrating with other Identity Providers (IdPs):


1. Character Limitations: The userId in Nextcloud supports fewer characters than the 'sub' claim defined in OpenID Connect: https://openid.net/specs/openid-connect-core-1_0.html#IDToken. To address this, we introduced an optional parameter that restricts the 'sub' claim to the character set permitted by Nextcloud.


2. Name Attribute Mapping: In Nextcloud, the 'name' attribute is mapped to the display name. However, the OpenID Connect specification typically defines 'given_name' and 'family_name' as separate claims: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims. To enhance OIDC support, it would be advantageous to construct the 'name' attribute by combining multiple relevant OIDC claims.


3. Birthdate Integration: Nextcloud offers the capability to display a user's birthdate. Since the birthdate is also a claim in the OpenID Connect specification, we have integrated it into the attribute mapping of the OIDC plugin. This helps to complete the user profile and is particularly beneficial for government applications like ID Austria.