### PR TITLE
feat: Add the ability to disable token client_secret_basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ $CONFIG = array (
     //	- 'plain'
     // The default value is empty, which won't apply the PKCE flow.
     'oidc_login_code_challenge_method' => 'S256',
+
+    // Disable token authentication method client_secret_basic.
+    // Some providers do not support client_secret_basic token authentication.
+    'oidc_disable_token_basic_auth' => false,
 );
 ```
 ### Usage with [Keycloak](https://www.keycloak.org/)

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ $CONFIG = array (
     'oidc_login_code_challenge_method' => 'S256',
 
     // Disable token authentication method client_secret_basic.
-    // Some providers do not support client_secret_basic token authentication.
+    // Some providers (e.g., Stalwart Mail) do not support client_secret_basic token authentication.
     'oidc_disable_token_basic_auth' => false,
 );
 ```

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -78,6 +78,11 @@ class LoginService
         $scope = $this->config->getSystemValue('oidc_login_scope', 'openid');
         $oidc->addScope($scope);
 
+        // Set disabling token client_secret_basic authentication
+        if ($this->config->getSystemValue('oidc_disable_token_basic_auth', false)) {
+            $oidc->setTokenEndpointAuthMethodsSupported([]);
+        }
+
         return $oidc;
     }
 


### PR DESCRIPTION
Closes #330 

I'm using this configuration option in my environment and it's working as expected. When disabled, my openid login fails with `invalid_client`, and when enabled openid login succeeds as expected.