### PR TITLE
Feature: Add automated Nextcloud compatibility workflow

### DIFF
--- a/.github/nextcloud-compatibility/compose.yml
+++ b/.github/nextcloud-compatibility/compose.yml
@@ -1,0 +1,66 @@
+# Author: Kevin Veen-Birkenbach <kevin@veen.world> - https://www.veen.world
+services:
+  db:
+    image: mariadb:10.11
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    environment:
+      MYSQL_DATABASE: nextcloud
+      MYSQL_PASSWORD: nextcloud
+      MYSQL_ROOT_PASSWORD: nextcloud
+      MYSQL_USER: nextcloud
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  nextcloud:
+    image: nextcloud:${NEXTCLOUD_IMAGE_TAG:-latest}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${NEXTCLOUD_HOST_PORT:-8080}:80"
+    environment:
+      MYSQL_DATABASE: nextcloud
+      MYSQL_HOST: db
+      MYSQL_PASSWORD: nextcloud
+      MYSQL_USER: nextcloud
+      NEXTCLOUD_ADMIN_PASSWORD: admin
+      NEXTCLOUD_ADMIN_USER: admin
+      NEXTCLOUD_TRUSTED_DOMAINS: 127.0.0.1 localhost host.docker.internal
+      OVERWRITECLIURL: http://127.0.0.1:${NEXTCLOUD_HOST_PORT:-8080}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ../../:/var/www/html/custom_apps/oidc_login:ro
+
+  mock-oauth2:
+    image: ghcr.io/navikt/mock-oauth2-server:latest
+    hostname: host.docker.internal
+    ports:
+      - "${MOCK_OAUTH2_HOST_PORT:-8090}:8080"
+    environment:
+      JSON_CONFIG: |
+        {
+          "interactiveLogin": false,
+          "httpServer": "NettyWrapper",
+          "tokenCallbacks": [
+            {
+              "issuerId": "default",
+              "requestMappings": [
+                {
+                  "requestParam": "code",
+                  "match": "*",
+                  "claims": {
+                    "sub": "oidc-ci-user",
+                    "name": "OIDC CI User",
+                    "email": "oidc-ci@example.test",
+                    "aud": ["nextcloud"],
+                    "groups": ["oidc"]
+                  }
+                }
+              ]
+            }
+          ]
+        }

--- a/.github/nextcloud-compatibility/run.sh
+++ b/.github/nextcloud-compatibility/run.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Author: Kevin Veen-Birkenbach <kevin@veen.world> - https://www.veen.world
+set -Eeuo pipefail
+
+APP_ID="${APP_ID:-oidc_login}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/compose.yml"
+INFO_XML="${REPO_ROOT}/appinfo/info.xml"
+PROJECT_NAME="${COMPOSE_PROJECT_NAME:-oidc-login-compat}"
+
+NEXTCLOUD_HOST_PORT="${NEXTCLOUD_HOST_PORT:-8080}"
+MOCK_OAUTH2_HOST_PORT="${MOCK_OAUTH2_HOST_PORT:-8090}"
+NEXTCLOUD_BASE_URL="${NEXTCLOUD_BASE_URL:-http://127.0.0.1:${NEXTCLOUD_HOST_PORT}}"
+MOCK_OAUTH2_BASE_URL="${MOCK_OAUTH2_BASE_URL:-http://127.0.0.1:${MOCK_OAUTH2_HOST_PORT}/default}"
+OIDC_PROVIDER_URL="${OIDC_PROVIDER_URL:-http://host.docker.internal:${MOCK_OAUTH2_HOST_PORT}/default}"
+NEXTCLOUD_IMAGE_TAG="${NEXTCLOUD_IMAGE_TAG:-latest}"
+UPDATE_INFO="${UPDATE_INFO:-0}"
+OIDC_USERNAME="${OIDC_USERNAME:-oidc-ci-user}"
+LAST_NEXTCLOUD_MAJOR=""
+
+export MOCK_OAUTH2_HOST_PORT
+export NEXTCLOUD_BASE_URL
+export NEXTCLOUD_HOST_PORT
+export NEXTCLOUD_IMAGE_TAG
+export OIDC_PROVIDER_URL
+
+write_output() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+compose() {
+  docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" "$@"
+}
+
+occ() {
+  compose exec -T -u www-data nextcloud php occ "$@"
+}
+
+cleanup() {
+  compose down -v --remove-orphans >/dev/null 2>&1 || true
+}
+
+finish() {
+  cleanup
+}
+
+read_app_version() {
+  python3 - "${INFO_XML}" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+print(root.findtext('version'))
+PY
+}
+
+read_nextcloud_max_version() {
+  python3 - "${INFO_XML}" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+dependency = root.find('./dependencies/nextcloud')
+print(dependency.attrib['max-version'])
+PY
+}
+
+update_nextcloud_max_version() {
+  python3 - "${INFO_XML}" "$1" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+version = sys.argv[2]
+content = path.read_text()
+updated = re.sub(
+    r'(<nextcloud\b[^>]*\bmax-version=")[^"]+(")',
+    rf'\g<1>{version}\2',
+    content,
+    count=1,
+)
+if updated == content:
+    raise SystemExit('Could not update nextcloud max-version in appinfo/info.xml')
+path.write_text(updated)
+PY
+}
+
+wait_for_url() {
+  local url="$1"
+
+  for _ in $(seq 1 90); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Timed out waiting for ${url}" >&2
+  return 1
+}
+
+wait_for_occ() {
+  local status
+
+  for _ in $(seq 1 120); do
+    if status="$(occ status --output=json 2>/dev/null)"; then
+      if printf '%s' "${status}" | python3 -c 'import json, sys; print(str(json.load(sys.stdin).get("installed") is True).lower())' | grep -qx true; then
+        return 0
+      fi
+    fi
+    sleep 3
+  done
+
+  echo 'Timed out waiting for Nextcloud occ.' >&2
+  return 1
+}
+
+nextcloud_major_version() {
+  local status
+  status="$(occ status --output=json)"
+  printf '%s' "${status}" | python3 -c 'import json, sys; payload = json.load(sys.stdin); version = payload.get("versionstring") or payload.get("version") or ""; print(str(version).split(".")[0])'
+}
+
+nextcloud_version_string() {
+  local status
+  status="$(occ status --output=json)"
+  printf '%s' "${status}" | python3 -c 'import json, sys; payload = json.load(sys.stdin); print(payload.get("versionstring") or payload.get("version") or "")'
+}
+
+configure_nextcloud() {
+  occ config:system:set trusted_domains 0 --value=127.0.0.1
+  occ config:system:set trusted_domains 1 --value=localhost
+  occ config:system:set trusted_domains 2 --value=host.docker.internal
+  occ config:system:set overwrite.cli.url --value="${NEXTCLOUD_BASE_URL}"
+  occ config:system:set oidc_login_provider_url --value="${OIDC_PROVIDER_URL}"
+  occ config:system:set oidc_login_client_id --value=nextcloud
+  occ config:system:set oidc_login_client_secret --value=nextcloud-secret
+  occ config:system:set oidc_login_auto_redirect --type=boolean --value=true
+  occ config:system:set oidc_login_disable_registration --type=boolean --value=false
+  occ config:system:set oidc_login_use_id_token --type=boolean --value=true
+  occ config:system:set oidc_login_tls_verify --type=boolean --value=false
+  occ config:system:set oidc_login_scope --value='openid profile email'
+  occ config:system:set oidc_login_code_challenge_method --value=''
+  occ config:system:set oidc_login_attributes id --value=sub
+  occ config:system:set oidc_login_attributes name --value=name
+  occ config:system:set oidc_login_attributes mail --value=email
+  occ config:system:set oidc_login_attributes groups --value=groups
+}
+
+print_diagnostics() {
+  compose ps || true
+  compose logs --no-color --tail=200 nextcloud mock-oauth2 || true
+}
+
+run_oidc_login() {
+  local body_file
+  local cookie_file
+  local login_succeeded
+  local user_response
+
+  body_file="$(mktemp)"
+  cookie_file="$(mktemp)"
+  login_succeeded=0
+
+  for _ in $(seq 1 10); do
+    if curl -fsSL \
+      --max-redirs 20 \
+      --resolve "host.docker.internal:${MOCK_OAUTH2_HOST_PORT}:127.0.0.1" \
+      --cookie "${cookie_file}" \
+      --cookie-jar "${cookie_file}" \
+      --output "${body_file}" \
+      "${NEXTCLOUD_BASE_URL}/login"; then
+      login_succeeded=1
+      break
+    fi
+    sleep 3
+  done
+
+  if [ "${login_succeeded}" != '1' ]; then
+    cat "${body_file}" >&2 || true
+    rm -f "${body_file}" "${cookie_file}"
+    return 1
+  fi
+
+  if ! user_response="$(curl -fsS \
+    --cookie "${cookie_file}" \
+    --header 'OCS-APIRequest: true' \
+    "${NEXTCLOUD_BASE_URL}/ocs/v2.php/cloud/user?format=json")"; then
+    cat "${body_file}" >&2 || true
+    rm -f "${body_file}" "${cookie_file}"
+    return 1
+  fi
+
+  printf '%s' "${user_response}" | python3 -c 'import json, sys
+expected_user = sys.argv[1]
+payload = json.load(sys.stdin)
+status_code = payload.get("ocs", {}).get("meta", {}).get("statuscode")
+user_id = payload.get("ocs", {}).get("data", {}).get("id")
+if status_code != 200 or user_id != expected_user:
+    raise SystemExit(f"OIDC login returned unexpected user payload: {payload!r}")' "${OIDC_USERNAME}"
+
+  rm -f "${body_file}" "${cookie_file}"
+}
+
+run_compatibility_test() {
+  cleanup
+
+  compose up -d || return 1
+  wait_for_url "${MOCK_OAUTH2_BASE_URL}/.well-known/openid-configuration" || return 1
+  wait_for_occ || return 1
+
+  local detected_version
+  local detected_major
+  detected_version="$(nextcloud_version_string)" || return 1
+  detected_major="$(nextcloud_major_version)" || return 1
+  LAST_NEXTCLOUD_MAJOR="${detected_major}"
+
+  write_output nextcloud_version "${detected_version}"
+  write_output nextcloud_major "${detected_major}"
+
+  configure_nextcloud || return 1
+  occ app:enable "${APP_ID}" || return 1
+  wait_for_url "${NEXTCLOUD_BASE_URL}/status.php" || return 1
+  run_oidc_login || return 1
+}
+
+main() {
+  trap finish EXIT
+
+  local app_version
+  local current_max
+  app_version="$(read_app_version)"
+  current_max="$(read_nextcloud_max_version)"
+
+  write_output app_version "${app_version}"
+  write_output current_max_version "${current_max}"
+  write_output changed false
+
+  echo "::group::Compatibility test with current appinfo/info.xml"
+  if run_compatibility_test; then
+    echo 'Current app metadata is installable and OIDC login works.'
+    echo '::endgroup::'
+    if [ "${UPDATE_INFO}" = '1' ] && [ "${current_max}" -lt "${LAST_NEXTCLOUD_MAJOR}" ]; then
+      update_nextcloud_max_version "${LAST_NEXTCLOUD_MAJOR}"
+      write_output proposed_max_version "${LAST_NEXTCLOUD_MAJOR}"
+      write_output changed true
+      echo "Prepared max-version update from ${current_max} to ${LAST_NEXTCLOUD_MAJOR}."
+    fi
+    return 0
+  fi
+  echo '::endgroup::'
+
+  if [ "${UPDATE_INFO}" != '1' ]; then
+    echo 'Compatibility test failed and UPDATE_INFO is not enabled.' >&2
+    print_diagnostics
+    return 1
+  fi
+
+  local target_major
+  target_major="${LAST_NEXTCLOUD_MAJOR}"
+  if [ -z "${target_major}" ]; then
+    target_major="$(nextcloud_major_version 2>/dev/null || true)"
+  fi
+  if [ -z "${target_major}" ]; then
+    echo 'Could not determine the latest Nextcloud major version.' >&2
+    print_diagnostics
+    return 1
+  fi
+
+  if [ "${current_max}" -ge "${target_major}" ]; then
+    echo "Current max-version (${current_max}) is already >= Nextcloud ${target_major}; not changing metadata." >&2
+    print_diagnostics
+    return 1
+  fi
+
+  local original_info
+  original_info="$(mktemp)"
+  cp "${INFO_XML}" "${original_info}"
+  update_nextcloud_max_version "${target_major}"
+  write_output proposed_max_version "${target_major}"
+
+  echo "::group::Compatibility test after raising max-version to ${target_major}"
+  if run_compatibility_test; then
+    echo "Nextcloud ${target_major} compatibility is green after updating max-version."
+    echo '::endgroup::'
+    write_output changed true
+    return 0
+  fi
+  echo '::endgroup::'
+
+  cp "${original_info}" "${INFO_XML}"
+  echo "Raising max-version to ${target_major} did not pass the compatibility test." >&2
+  print_diagnostics
+  return 1
+}
+
+main "$@"

--- a/.github/workflows/nextcloud-compatibility.yaml
+++ b/.github/workflows/nextcloud-compatibility.yaml
@@ -1,0 +1,57 @@
+# Author: Kevin Veen-Birkenbach <kevin@veen.world> - https://www.veen.world
+---
+name: Nextcloud compatibility
+
+on:
+  workflow_dispatch:
+    inputs:
+      nextcloud_image_tag:
+        description: Nextcloud Docker image tag to test
+        required: false
+        default: latest
+  schedule:
+    - cron: "23 4 * * *"
+  pull_request:
+    paths:
+      - "3rdparty/**"
+      - "appinfo/info.xml"
+      - "lib/**"
+      - ".github/nextcloud-compatibility/**"
+      - ".github/workflows/nextcloud-compatibility.yaml"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: nextcloud-compatibility-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Test latest Nextcloud compatibility
+        id: compatibility
+        env:
+          NEXTCLOUD_IMAGE_TAG: ${{ github.event.inputs.nextcloud_image_tag || 'latest' }}
+          UPDATE_INFO: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+        run: .github/nextcloud-compatibility/run.sh
+
+      - name: Create compatibility pull request
+        if: steps.compatibility.outputs.changed == 'true' && github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-nextcloud-${{ steps.compatibility.outputs.nextcloud_major }}
+          commit-message: Update Nextcloud max-version to ${{ steps.compatibility.outputs.nextcloud_major }}
+          delete-branch: true
+          title: Update Nextcloud max-version to ${{ steps.compatibility.outputs.nextcloud_major }}
+          body: |
+            Automated compatibility check passed for Nextcloud ${{ steps.compatibility.outputs.nextcloud_version }}.
+
+            This updates `appinfo/info.xml` from max-version `${{ steps.compatibility.outputs.current_max_version }}` to `${{ steps.compatibility.outputs.nextcloud_major }}` after verifying:
+
+            - the app can be enabled in a fresh Nextcloud container
+            - OIDC login succeeds against the compose-based mock OAuth2/OIDC provider

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,12 +3,105 @@ name: release
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - appinfo/info.xml
 
 env:
   APP_NAME: oidc_login
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      should_publish: ${{ steps.meta.outputs.should_publish }}
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Detect release metadata
+      id: meta
+      env:
+        RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: |
+        if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+          {
+            echo "should_publish=true"
+            echo "tag=${RELEASE_TAG}"
+            echo "version=${RELEASE_TAG#v}"
+            echo "prerelease=${RELEASE_PRERELEASE}"
+          } >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        current_version="$(python3 - <<'PY'
+        import xml.etree.ElementTree as ET
+        print(ET.parse('appinfo/info.xml').getroot().findtext('version'))
+        PY
+        )"
+
+        previous_version="$(
+          git show "${{ github.event.before }}:appinfo/info.xml" 2>/dev/null |
+          python3 -c 'import sys, xml.etree.ElementTree as ET; print(ET.fromstring(sys.stdin.read()).findtext("version"))' 2>/dev/null ||
+          true
+        )"
+
+        is_bump="$(python3 - "${previous_version}" "${current_version}" <<'PY'
+        import sys
+
+        def version_tuple(value):
+            return tuple(int(part) for part in value.split('.'))
+
+        previous, current = sys.argv[1], sys.argv[2]
+        if not previous:
+            print('false')
+        else:
+            print(str(version_tuple(current) > version_tuple(previous)).lower())
+        PY
+        )"
+
+        if [ "${is_bump}" != "true" ]; then
+          echo "should_publish=false" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        {
+          echo "should_publish=true"
+          echo "tag=v${current_version}"
+          echo "version=${current_version}"
+          echo "prerelease=false"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Create GitHub release for version bump
+      if: github.event_name == 'push' && steps.meta.outputs.should_publish == 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ steps.meta.outputs.tag }}
+        VERSION: ${{ steps.meta.outputs.version }}
+      run: |
+        if gh release view "${TAG}" >/dev/null 2>&1; then
+          exit 0
+        fi
+
+        gh release create "${TAG}" \
+          --target "${GITHUB_SHA}" \
+          --title "${TAG}" \
+          --notes "Automated release for ${APP_NAME} ${VERSION}."
+
   publish:
+    needs: prepare
+    if: needs.prepare.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,7 +123,7 @@ jobs:
       with:
         file: oidc_login.tar.gz
         asset_name: oidc_login.tar.gz
-        tag: ${{ github.ref }}
+        tag: ${{ needs.prepare.outputs.tag }}
         overwrite: true
 
     - name: Upload app to Nextcloud appstore
@@ -40,4 +133,4 @@ jobs:
         appstore_token: ${{ secrets.APPSTORE_TOKEN }}
         download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-        nightly: ${{ github.event.release.prerelease }}
+        nightly: ${{ needs.prepare.outputs.prerelease }}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,6 +32,6 @@ Provides user creation and login via one single OpenID Connect provider. Even th
     <repository>https://github.com/pulsejet/nextcloud-single-openid-connect</repository>
     <screenshot>https://raw.githubusercontent.com/pulsejet/nextcloud-single-openid-connect/master/appinfo/screenshot.png</screenshot>
     <dependencies>
-        <nextcloud min-version="30" max-version="33" />
+        <nextcloud min-version="30" max-version="34" />
     </dependencies>
 </info>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -95,7 +95,7 @@ class Application extends App implements IBootstrap
             /* Redirect to logout URL on completing logout
                If do not have logout URL, go to noredir on logout */
             if ($logoutUrl = $session->get('oidc_logout_url', $noRedirLoginUrl)) {
-                $userSession->listen('\OC\User', 'postLogout', function () use ($logoutUrl, $session) {
+                $userSession->listen('\OC\User', 'postLogout', function () use ($logoutUrl, $session): void {
                     // Do nothing if this is a CORS request
                     if ($this->getContainer()->get(ControllerMethodReflector::class)->hasAnnotation('CORS')) {
                         return;

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\OIDCLogin\Controller;
 
 use OCA\OIDCLogin\Provider\OpenIDConnectClient;

--- a/lib/OIDCLoginOption.php
+++ b/lib/OIDCLoginOption.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\OIDCLogin;
 
 use OCP\Authentication\IAlternativeLogin;

--- a/lib/Provider/OpenIDConnectClient.php
+++ b/lib/Provider/OpenIDConnectClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\OIDCLogin\Provider;
 
 require_once __DIR__.'/../../3rdparty/autoload.php';
@@ -219,22 +221,22 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
         return $this->session->get($key);
     }
 
-    protected function setSessionKey($key, $value)
+    protected function setSessionKey($key, $value): void
     {
         $this->session->set($key, $value);
     }
 
-    protected function unsetSessionKey($key)
+    protected function unsetSessionKey($key): void
     {
         $this->session->remove($key);
     }
 
-    protected function startSession()
+    protected function startSession(): void
     {
         $this->session->set('is_oidc', 1);
     }
 
-    protected function commitSession()
+    protected function commitSession(): void
     {
         $this->startSession();
     }

--- a/lib/Service/AttributeMap.php
+++ b/lib/Service/AttributeMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\OIDCLogin\Service;
 
 use OCP\IConfig;

--- a/lib/Service/LoginService.php
+++ b/lib/Service/LoginService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\OIDCLogin\Service;
 
 use OC\Authentication\Token\IProvider;

--- a/lib/WebDAV/BasicAuthBackend.php
+++ b/lib/WebDAV/BasicAuthBackend.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\OIDCLogin\WebDAV;
 
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
@@ -108,7 +110,7 @@ class BasicAuthBackend extends AbstractBasic implements IEventListener
         return $this->principalPrefix.$userId;
     }
 
-    private function login(string $username, string $password)
+    private function login(string $username, string $password): void
     {
         $client = $this->loginService->createOIDCClient();
         if (null === $client) {

--- a/lib/WebDAV/BearerAuthBackend.php
+++ b/lib/WebDAV/BearerAuthBackend.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OCA\OIDCLogin\WebDAV;
 
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
@@ -105,7 +107,7 @@ class BearerAuthBackend extends AbstractBearer implements IEventListener
      *
      * @param string $bearerToken an OIDC JWT bearer token
      */
-    private function login(string $bearerToken)
+    private function login(string $bearerToken): void
     {
         $client = $this->loginService->createOIDCClient();
         if (null === $client) {


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow to test whether the app is installable on the current Nextcloud version.
- Starts a Compose-based test stack with Nextcloud, MariaDB, and `ghcr.io/navikt/mock-oauth2-server:latest`.
- Verifies that the app can be enabled and that an OIDC login succeeds against the mock provider.
- Automatically raises the supported Nextcloud `max-version` in `appinfo/info.xml` when the latest Nextcloud version passes compatibility checks.
- Creates a compatibility update PR automatically when metadata changes are generated.
- Extends the release workflow so a version bump in `appinfo/info.xml` on `main`/`master` triggers a release.

## Validation

- `bash -n .github/nextcloud-compatibility/run.sh`
- `shellcheck .github/nextcloud-compatibility/run.sh`
- `actionlint .github/workflows/release.yaml .github/workflows/nextcloud-compatibility.yaml`
- `git diff --check`
- `act workflow_dispatch -W .github/workflows/nextcloud-compatibility.yaml -j compatibility --input nextcloud_image_tag=34 ...`

The `act` run completed successfully against Nextcloud `34.0.1`, including app activation and OIDC login.